### PR TITLE
Add runtime roll forward

### DIFF
--- a/src/runtimeconfig.template.json
+++ b/src/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+  "rollForwardOnNoCandidateFx": 2
+}


### PR DESCRIPTION
Or it will fail with following error on a machine with only 3.0 runtime. We hope to set this as default in 3.0

```
It was not possible to find any compatible framework version
The specified framework 'Microsoft.NETCore.App', version '2.1.0' was not found.
  - Check application dependencies and target a framework version installed at:
      C:\Program Files\dotnet
  - The .NET Core Runtime and SDK can be installed from:
      https://aka.ms/dotnet-download
  - The following versions are installed:
      3.0.0-preview3-27425-4 at [C:\Program Files\dotnet\shared\Microsoft.NETCore.App]
  - Installing .NET Core prerequisites might help resolve this problem:
      https://go.microsoft.com/fwlink/?linkid=798306
```

https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/roll-forward-on-no-candidate-fx.md