### PR TITLE
Set current directory to the workspace directory

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -58,6 +58,8 @@ namespace Microsoft.CodeAnalysis.Tools.CodeFormatter
 
             try
             {
+                currentDirectory = Environment.CurrentDirectory;
+
                 var workingDirectory = Directory.GetCurrentDirectory();
                 var (isSolution, workspacePath) = MSBuildWorkspaceFinder.FindWorkspace(workingDirectory, workspace);
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -54,6 +54,8 @@ namespace Microsoft.CodeAnalysis.Tools.CodeFormatter
                 cancellationTokenSource.Cancel();
             };
 
+            string currentDirectory = string.Empty;
+
             try
             {
                 var workingDirectory = Directory.GetCurrentDirectory();
@@ -63,6 +65,7 @@ namespace Microsoft.CodeAnalysis.Tools.CodeFormatter
                 // workspace, use its directory as our working directory which will take into account
                 // a global.json if present.
                 var workspaceDirectory = Path.GetDirectoryName(workspacePath);
+                Environment.CurrentDirectory = workingDirectory;
 
                 // Since we are running as a dotnet tool we should be able to find an instance of
                 // MSBuild in a .NET Core SDK.
@@ -85,6 +88,13 @@ namespace Microsoft.CodeAnalysis.Tools.CodeFormatter
             catch (OperationCanceledException)
             {
                 return 1;
+            }
+            finally
+            {
+                if (!string.IsNullOrEmpty(currentDirectory))
+                {
+                    Environment.CurrentDirectory = currentDirectory;
+                }
             }
         }
 


### PR DESCRIPTION
After merging the change to use MSBuildLocator we no longer ensured the sdk set in the workspaces global.json would get picked up when locating msbuild. This change updates the current directory to the workspace's directory to restore this behavior.