### PR TITLE
Add dry-run option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Options:
   -v, --verbosity    Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and
                      diag[nostic]
   --check            Terminate with non-zero exit code if any files formatted.
+  --dry-run          Format files, but do not save changes to disk.
   --version          Display version information
 ```
 


### PR DESCRIPTION
The dry-run option was missing from the README, so I added it. I took the text from within the project.