### PR TITLE
Add package icon URL

### DIFF
--- a/src/dotnet-format.csproj
+++ b/src/dotnet-format.csproj
@@ -6,6 +6,7 @@
     <LangVersion>7.3</LangVersion> 
     <RootNamespace>Microsoft.CodeAnalysis.Tools</RootNamespace>
     <Description>Command line tool for formatting C# and Visual Basic code files based on .editorconfig settings.</Description>
+    <PackageIconUrl>https://go.microsoft.com/fwlink/?LinkID=288859</PackageIconUrl>
 
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <IsPackable>true</IsPackable>


### PR DESCRIPTION
The package on nuget.org has no icon: https://www.nuget.org/packages/dotnet-format/

I used the same link as in the [AspNetCore-Tooling repository](https://github.com/aspnet/AspNetCore-Tooling/blob/d4460f110eb5aa76e0b84fd03ab5ddd5f083d489/Directory.Build.props#L33).