### PR TITLE
Check that code files excluded by .editorconfig are not formatted

### DIFF
--- a/tests/CodeFormatterTests.cs
+++ b/tests/CodeFormatterTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
                 EmptyFilesToFormat,
                 expectedExitCode: 0,
                 expectedFilesFormatted: 2,
-                expectedFileCount: 4);
+                expectedFileCount: 5);
         }
 
         [Fact]
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
                 EmptyFilesToFormat,
                 expectedExitCode: 0,
                 expectedFilesFormatted: 2,
-                expectedFileCount: 4);
+                expectedFileCount: 5);
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
                 filesToFormat,
                 expectedExitCode: 0,
                 expectedFilesFormatted: 1,
-                expectedFileCount: 4);
+                expectedFileCount: 5);
         }
 
         [Fact]
@@ -119,7 +119,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
                 files,
                 expectedExitCode: 0,
                 expectedFilesFormatted: 0,
-                expectedFileCount: 4);
+                expectedFileCount: 5);
         }
 
         [Fact]
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
                 files,
                 expectedExitCode: 0,
                 expectedFilesFormatted: 1,
-                expectedFileCount: 4);
+                expectedFileCount: 5);
 
             var pattern = string.Format(Resources.Formatted_code_file_0, @"(.*)");
             var match = new Regex(pattern, RegexOptions.Multiline).Match(log);

--- a/tests/projects/for_code_formatter/unformatted_project/.editorconfig
+++ b/tests/projects/for_code_formatter/unformatted_project/.editorconfig
@@ -2,7 +2,7 @@
 root = true
 
 # C# files
-[*.cs]
+[{Program.cs,other_items/*.cs}]
 
 #### Core EditorConfig Options ####
 

--- a/tests/projects/for_code_formatter/unformatted_project/ignored_items/IgnoredClass.cs
+++ b/tests/projects/for_code_formatter/unformatted_project/ignored_items/IgnoredClass.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace for_code_formatter
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}


### PR DESCRIPTION
The PR adds an "ignored_items\IgnoreClass.cs" to the unformatted_project and updates the .editorconfig to exclude the the "ignored_items" folder. The tests show that total file count increased by 1, but files formatted did not increase. The behavior change was part of the refactoring of the format pipeline.

Closes #8