### PR TITLE
Log formatting change details when in dry-run mode

### DIFF
--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -26,22 +26,21 @@ namespace Microsoft.CodeAnalysis.Tools
         }.ToImmutableArray();
 
         public static async Task<WorkspaceFormatResult> FormatWorkspaceAsync(
-            string solutionOrProjectPath,
-            bool isSolution,
-            bool logWorkspaceWarnings,
-            bool saveFormattedFiles,
-            ImmutableHashSet<string> filesToFormat,
+            FormatOptions options,
             ILogger logger,
             CancellationToken cancellationToken)
         {
-            logger.LogInformation(string.Format(Resources.Formatting_code_files_in_workspace_0, solutionOrProjectPath));
+            var (workspaceFilePath, isSolution, logLevel, saveFormattedFiles, filesToFormat) = options;
+            var logWorkspaceWarnings = logLevel == LogLevel.Trace;
+
+            logger.LogInformation(string.Format(Resources.Formatting_code_files_in_workspace_0, workspaceFilePath));
 
             logger.LogTrace(Resources.Loading_workspace);
 
             var workspaceStopwatch = Stopwatch.StartNew();
 
             using (var workspace = await OpenWorkspaceAsync(
-                solutionOrProjectPath, isSolution, logWorkspaceWarnings, logger, cancellationToken).ConfigureAwait(false))
+                workspaceFilePath, isSolution, logWorkspaceWarnings, logger, cancellationToken).ConfigureAwait(false))
             {
                 if (workspace is null)
                 {
@@ -51,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Tools
                 var loadWorkspaceMS = workspaceStopwatch.ElapsedMilliseconds;
                 logger.LogTrace(Resources.Complete_in_0_ms, workspaceStopwatch.ElapsedMilliseconds);
 
-                var projectPath = isSolution ? string.Empty : solutionOrProjectPath;
+                var projectPath = isSolution ? string.Empty : workspaceFilePath;
                 var solution = workspace.CurrentSolution;
 
                 logger.LogTrace(Resources.Determining_formattable_files);
@@ -65,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Tools
                 logger.LogTrace(Resources.Running_formatters);
 
                 var formattedSolution = await RunCodeFormattersAsync(
-                    solution, formatableFiles, logger, cancellationToken).ConfigureAwait(false);
+                    solution, formatableFiles, options, logger, cancellationToken).ConfigureAwait(false);
 
                 var formatterRanMS = workspaceStopwatch.ElapsedMilliseconds - loadWorkspaceMS - determineFilesMS;
                 logger.LogTrace(Resources.Complete_in_0_ms, formatterRanMS);
@@ -165,6 +164,7 @@ namespace Microsoft.CodeAnalysis.Tools
         private static async Task<Solution> RunCodeFormattersAsync(
             Solution solution,
             ImmutableArray<(Document, OptionSet, ICodingConventionsSnapshot)> formattableDocuments,
+            FormatOptions options,
             ILogger logger,
             CancellationToken cancellationToken)
         {
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.Tools
 
             foreach (var codeFormatter in s_codeFormatters)
             {
-                formattedSolution = await codeFormatter.FormatAsync(formattedSolution, formattableDocuments, logger, cancellationToken).ConfigureAwait(false);
+                formattedSolution = await codeFormatter.FormatAsync(formattedSolution, formattableDocuments, options, logger, cancellationToken).ConfigureAwait(false);
             }
 
             return formattedSolution;

--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Tools
             ILogger logger,
             CancellationToken cancellationToken)
         {
-            var (workspaceFilePath, isSolution, logLevel, saveFormattedFiles, filesToFormat) = options;
+            var (workspaceFilePath, isSolution, logLevel, saveFormattedFiles, _, filesToFormat) = options;
             var logWorkspaceWarnings = logLevel == LogLevel.Trace;
 
             logger.LogInformation(string.Format(Resources.Formatting_code_files_in_workspace_0, workspaceFilePath));

--- a/src/FormatOptions.cs
+++ b/src/FormatOptions.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CodeAnalysis.Tools
         public bool IsSolution { get; }
         public LogLevel LogLevel { get; }
         public bool SaveFormattedFiles { get; }
+        public bool ChangesAreErrors { get; }
         public ImmutableHashSet<string> FilesToFormat { get; }
 
         public FormatOptions(
@@ -16,12 +17,14 @@ namespace Microsoft.CodeAnalysis.Tools
             bool isSolution,
             LogLevel logLevel,
             bool saveFormattedFiles,
+            bool changesAreErrors,
             ImmutableHashSet<string> filesToFormat)
         {
             WorkspaceFilePath = workspaceFilePath;
             IsSolution = isSolution;
             LogLevel = logLevel;
             SaveFormattedFiles = saveFormattedFiles;
+            ChangesAreErrors = changesAreErrors;
             FilesToFormat = filesToFormat;
         }
 
@@ -30,12 +33,14 @@ namespace Microsoft.CodeAnalysis.Tools
             out bool isSolution,
             out LogLevel logLevel,
             out bool saveFormattedFiles,
+            out bool changesAreErrors,
             out ImmutableHashSet<string> filesToFormat)
         {
             workspaceFilePath = WorkspaceFilePath;
             isSolution = IsSolution;
             logLevel = LogLevel;
             saveFormattedFiles = SaveFormattedFiles;
+            changesAreErrors = ChangesAreErrors;
             filesToFormat = FilesToFormat;
         }
     }

--- a/src/FormatOptions.cs
+++ b/src/FormatOptions.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Immutable;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.CodeAnalysis.Tools
+{
+    internal class FormatOptions
+    {
+        public string WorkspaceFilePath { get; }
+        public bool IsSolution { get; }
+        public LogLevel LogLevel { get; }
+        public bool SaveFormattedFiles { get; }
+        public ImmutableHashSet<string> FilesToFormat { get; }
+
+        public FormatOptions(
+            string workspaceFilePath,
+            bool isSolution,
+            LogLevel logLevel,
+            bool saveFormattedFiles,
+            ImmutableHashSet<string> filesToFormat)
+        {
+            WorkspaceFilePath = workspaceFilePath;
+            IsSolution = isSolution;
+            LogLevel = logLevel;
+            SaveFormattedFiles = saveFormattedFiles;
+            FilesToFormat = filesToFormat;
+        }
+
+        public void Deconstruct(
+            out string workspaceFilePath,
+            out bool isSolution,
+            out LogLevel logLevel,
+            out bool saveFormattedFiles,
+            out ImmutableHashSet<string> filesToFormat)
+        {
+            workspaceFilePath = WorkspaceFilePath;
+            isSolution = IsSolution;
+            logLevel = LogLevel;
+            saveFormattedFiles = SaveFormattedFiles;
+            filesToFormat = FilesToFormat;
+        }
+    }
+}

--- a/src/Formatters/FinalNewlineFormatter.cs
+++ b/src/Formatters/FinalNewlineFormatter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
 {
     internal sealed class FinalNewlineFormatter : DocumentFormatter
     {
-        protected override string FormatWarningDescription => "Add final newline.";
+        protected override string FormatWarningDescription => Resources.Add_final_newline;
 
         protected override async Task<SourceText> FormatFileAsync(
             Document document,

--- a/src/Formatters/FinalNewlineFormatter.cs
+++ b/src/Formatters/FinalNewlineFormatter.cs
@@ -13,6 +13,8 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
 {
     internal sealed class FinalNewlineFormatter : DocumentFormatter
     {
+        protected override string FormatWarningDescription => "Add final newline.";
+
         protected override async Task<SourceText> FormatFileAsync(
             Document document,
             OptionSet options,

--- a/src/Formatters/FinalNewlineFormatter.cs
+++ b/src/Formatters/FinalNewlineFormatter.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
             Document document,
             OptionSet options,
             ICodingConventionsSnapshot codingConventions,
+            FormatOptions formatOptions,
             ILogger logger,
             CancellationToken cancellationToken)
         {

--- a/src/Formatters/ICodeFormatter.cs
+++ b/src/Formatters/ICodeFormatter.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
         Task<Solution> FormatAsync(
             Solution solution,
             ImmutableArray<(Document, OptionSet, ICodingConventionsSnapshot)> formattableDocuments,
+            FormatOptions options,
             ILogger logger,
             CancellationToken cancellationToken);
     }

--- a/src/Formatters/WhitespaceFormatter.cs
+++ b/src/Formatters/WhitespaceFormatter.cs
@@ -15,6 +15,8 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
     /// </summary>
     internal sealed class WhitespaceFormatter : DocumentFormatter
     {
+        protected override string FormatWarningDescription => "Fix whitespace formatting.";
+
         protected override async Task<SourceText> FormatFileAsync(
             Document document,
             OptionSet options,

--- a/src/Formatters/WhitespaceFormatter.cs
+++ b/src/Formatters/WhitespaceFormatter.cs
@@ -52,9 +52,9 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
         private static async Task<SourceText> GetFormattedDocumentWithDetailedChanges(Document document, OptionSet options, CancellationToken cancellationToken)
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken);
-            var formattingTextChanges = Formatter.GetFormattedTextChanges(root, document.Project.Solution.Workspace, options, cancellationToken);
-
             var originalText = await document.GetTextAsync(cancellationToken);
+
+            var formattingTextChanges = Formatter.GetFormattedTextChanges(root, document.Project.Solution.Workspace, options, cancellationToken);
             return originalText.WithChanges(formattingTextChanges);
         }
     }

--- a/src/Formatters/WhitespaceFormatter.cs
+++ b/src/Formatters/WhitespaceFormatter.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System.Buffers;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Formatting;
@@ -21,11 +23,39 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
             Document document,
             OptionSet options,
             ICodingConventionsSnapshot codingConventions,
+            FormatOptions formatOptions,
             ILogger logger,
             CancellationToken cancellationToken)
         {
+            if (formatOptions.SaveFormattedFiles)
+            {
+                return await GetFormattedDocument(document, options, cancellationToken);
+            }
+            else
+            {
+                return await GetFormattedDocumentWithDetailedChanges(document, options, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Returns a formatted <see cref="SourceText"/> with a single <see cref="TextChange"/> that encompasses the entire document.
+        /// </summary>
+        private static async Task<SourceText> GetFormattedDocument(Document document, OptionSet options, CancellationToken cancellationToken)
+        {
             var formattedDocument = await Formatter.FormatAsync(document, options, cancellationToken).ConfigureAwait(false);
             return await formattedDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Returns a formatted <see cref="SoureText"/> with multiple <see cref="TextChange"/>s for each formatting change.
+        /// </summary>
+        private static async Task<SourceText> GetFormattedDocumentWithDetailedChanges(Document document, OptionSet options, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken);
+            var formattingTextChanges = Formatter.GetFormattedTextChanges(root, document.Project.Solution.Workspace, options, cancellationToken);
+
+            var originalText = await document.GetTextAsync(cancellationToken);
+            return originalText.WithChanges(formattingTextChanges);
         }
     }
 }

--- a/src/Formatters/WhitespaceFormatter.cs
+++ b/src/Formatters/WhitespaceFormatter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
     /// </summary>
     internal sealed class WhitespaceFormatter : DocumentFormatter
     {
-        protected override string FormatWarningDescription => "Fix whitespace formatting.";
+        protected override string FormatWarningDescription => Resources.Fix_whitespace_formatting;
 
         protected override async Task<SourceText> FormatFileAsync(
             Document document,

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -93,6 +93,7 @@ namespace Microsoft.CodeAnalysis.Tools
                     isSolution,
                     logLevel,
                     saveFormattedFiles: !dryRun,
+                    changesAreErrors: check,
                     filesToFormat);
 
                 var formatResult = await CodeFormatter.FormatWorkspaceAsync(

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -88,12 +88,15 @@ namespace Microsoft.CodeAnalysis.Tools
 
                 Build.Locator.MSBuildLocator.RegisterInstance(msBuildInstance);
 
-                var formatResult = await CodeFormatter.FormatWorkspaceAsync(
+                var formatOptions = new FormatOptions(
                     workspacePath,
                     isSolution,
-                    logWorkspaceWarnings: logLevel == LogLevel.Trace,
+                    logLevel,
                     saveFormattedFiles: !dryRun,
-                    filesToFormat,
+                    filesToFormat);
+
+                var formatResult = await CodeFormatter.FormatWorkspaceAsync(
+                    formatOptions,
                     logger,
                     cancellationTokenSource.Token).ConfigureAwait(false);
 

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -192,4 +192,10 @@
   <data name="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings" xml:space="preserve">
     <value>Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</value>
   </data>
+  <data name="Add_final_newline" xml:space="preserve">
+    <value>Add final newline.</value>
+  </data>
+  <data name="Fix_whitespace_formatting" xml:space="preserve">
+    <value>Fix whitespace formatting.</value>
+  </data>
 </root>

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_final_newline">
+        <source>Add final newline.</source>
+        <target state="new">Add final newline.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">{0} obsahuje jak soubor projektu MSBuild, tak soubor řešení. Určete, který soubor chcete použít, pomocí parametru --workspace.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">Nepodařilo se uložit změny formátování.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_whitespace_formatting">
+        <source>Fix whitespace formatting.</source>
+        <target state="new">Fix whitespace formatting.</target>
         <note />
       </trans-unit>
       <trans-unit id="Format_complete_in_0_ms">

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_final_newline">
+        <source>Add final newline.</source>
+        <target state="new">Add final newline.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">In "{0}" wurden eine MSBuild-Projektdatei und eine Projektmappe gefunden. Geben Sie mit der Option "--workspace" an, welche verwendet werden soll.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">Fehler beim Speichern von Formatierungsänderungen.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_whitespace_formatting">
+        <source>Fix whitespace formatting.</source>
+        <target state="new">Fix whitespace formatting.</target>
         <note />
       </trans-unit>
       <trans-unit id="Format_complete_in_0_ms">

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_final_newline">
+        <source>Add final newline.</source>
+        <target state="new">Add final newline.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">Se encontró un archivo de proyecto y un archivo de solución MSBuild en "{0}". Especifique cuál debe usarse con la opción --workspace.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">Error al guardar cambios de formato.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_whitespace_formatting">
+        <source>Fix whitespace formatting.</source>
+        <target state="new">Fix whitespace formatting.</target>
         <note />
       </trans-unit>
       <trans-unit id="Format_complete_in_0_ms">

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_final_newline">
+        <source>Add final newline.</source>
+        <target state="new">Add final newline.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">Un fichier projet et un fichier solution MSBuild ont été trouvés dans '{0}'. Spécifiez celui à utiliser avec l'option --workspace.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">L'enregistrement des changements de mise en forme a échoué.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_whitespace_formatting">
+        <source>Fix whitespace formatting.</source>
+        <target state="new">Fix whitespace formatting.</target>
         <note />
       </trans-unit>
       <trans-unit id="Format_complete_in_0_ms">

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_final_newline">
+        <source>Add final newline.</source>
+        <target state="new">Add final newline.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">In '{0}' sono stati trovati sia un file di progetto che un file di soluzione MSBuild. Per specificare quello desiderato, usare l'opzione --workspace.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">Non è stato possibile salvare le modifiche di formattazione.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_whitespace_formatting">
+        <source>Fix whitespace formatting.</source>
+        <target state="new">Fix whitespace formatting.</target>
         <note />
       </trans-unit>
       <trans-unit id="Format_complete_in_0_ms">

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_final_newline">
+        <source>Add final newline.</source>
+        <target state="new">Add final newline.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">MSBuild プロジェクト ファイルとソリューション ファイルが '{0}' で見つかりました。使用するファイルを --workspace オプションで指定してください。</target>
@@ -35,6 +40,11 @@
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">書式変更を保存できませんでした。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_whitespace_formatting">
+        <source>Fix whitespace formatting.</source>
+        <target state="new">Fix whitespace formatting.</target>
         <note />
       </trans-unit>
       <trans-unit id="Format_complete_in_0_ms">

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_final_newline">
+        <source>Add final newline.</source>
+        <target state="new">Add final newline.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">'{0}'에 MSBuild 프로젝트 파일 및 솔루션 파일이 모두 있습니다. --workspace 옵션에 사용할 파일을 지정하세요.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">서식 변경 내용을 저장하지 못했습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_whitespace_formatting">
+        <source>Fix whitespace formatting.</source>
+        <target state="new">Fix whitespace formatting.</target>
         <note />
       </trans-unit>
       <trans-unit id="Format_complete_in_0_ms">

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_final_newline">
+        <source>Add final newline.</source>
+        <target state="new">Add final newline.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">W elemencie „{0}” znaleziono zarówno plik rozwiązania, jak i plik projektu MSBuild. Określ plik do użycia za pomocą opcji --workspace.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">Nie można zapisać zmian formatowania.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_whitespace_formatting">
+        <source>Fix whitespace formatting.</source>
+        <target state="new">Fix whitespace formatting.</target>
         <note />
       </trans-unit>
       <trans-unit id="Format_complete_in_0_ms">

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_final_newline">
+        <source>Add final newline.</source>
+        <target state="new">Add final newline.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">Foram encontrados um arquivo de solução e um arquivo de projeto MSBuild em '{0}'. Especifique qual usar com a opção --espaço de trabalho.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">Falha ao salvar alterações de formatação.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_whitespace_formatting">
+        <source>Fix whitespace formatting.</source>
+        <target state="new">Fix whitespace formatting.</target>
         <note />
       </trans-unit>
       <trans-unit id="Format_complete_in_0_ms">

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_final_newline">
+        <source>Add final newline.</source>
+        <target state="new">Add final newline.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">В "{0}" обнаружены как файл проекта, так и файл решения MSBuild. Укажите используемый файл с помощью параметра --workspace.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">Не удалось сохранить изменения форматирования.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_whitespace_formatting">
+        <source>Fix whitespace formatting.</source>
+        <target state="new">Fix whitespace formatting.</target>
         <note />
       </trans-unit>
       <trans-unit id="Format_complete_in_0_ms">

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_final_newline">
+        <source>Add final newline.</source>
+        <target state="new">Add final newline.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">Hem bir MSBuild proje dosyası ve çözüm dosyası '{0}' içinde bulundu. Hangi--çalışma alanı seçeneği ile kullanmak için belirtin.</target>
@@ -35,6 +40,11 @@
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">Biçimlendirme değişiklikleri kaydedilemedi.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_whitespace_formatting">
+        <source>Fix whitespace formatting.</source>
+        <target state="new">Fix whitespace formatting.</target>
         <note />
       </trans-unit>
       <trans-unit id="Format_complete_in_0_ms">

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_final_newline">
+        <source>Add final newline.</source>
+        <target state="new">Add final newline.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">在“{0}”中同时找到 MSBuild 项目文件和解决方案文件。请指定要将哪一个文件用于 --workspace 选项。</target>
@@ -35,6 +40,11 @@
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">未能保存格式更改。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_whitespace_formatting">
+        <source>Fix whitespace formatting.</source>
+        <target state="new">Fix whitespace formatting.</target>
         <note />
       </trans-unit>
       <trans-unit id="Format_complete_in_0_ms">

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Add_final_newline">
+        <source>Add final newline.</source>
+        <target state="new">Add final newline.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">在 '{0}' 中同時找到 MSBuild 專案檔和解決方案檔。請指定要搭配 --workspace 選項使用的檔案。</target>
@@ -35,6 +40,11 @@
       <trans-unit id="Failed_to_save_formatting_changes">
         <source>Failed to save formatting changes.</source>
         <target state="translated">無法儲存格式化變更。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_whitespace_formatting">
+        <source>Fix whitespace formatting.</source>
+        <target state="new">Fix whitespace formatting.</target>
         <note />
       </trans-unit>
       <trans-unit id="Format_complete_in_0_ms">

--- a/tests/CodeFormatterTests.cs
+++ b/tests/CodeFormatterTests.cs
@@ -161,10 +161,22 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
 
             var expectedFormatLocations = new[]
             {
-                @"other_items\OtherClass.cs(0,0): Fix whitespace formatting.",
-                @"Program.cs(0,0): Fix whitespace formatting.",
-                @"other_items\OtherClass.cs(11,1): Add final newline.",
-                @"Program.cs(11,1): Add final newline.",
+                @"other_items\OtherClass.cs(5,3): Fix whitespace formatting.",
+                @"other_items\OtherClass.cs(6,3): Fix whitespace formatting.",
+                @"other_items\OtherClass.cs(7,5): Fix whitespace formatting.",
+                @"other_items\OtherClass.cs(8,5): Fix whitespace formatting.",
+                @"other_items\OtherClass.cs(9,7): Fix whitespace formatting.",
+                @"other_items\OtherClass.cs(10,5): Fix whitespace formatting.",
+                @"other_items\OtherClass.cs(11,3): Fix whitespace formatting.",
+                @"Program.cs(5,3): Fix whitespace formatting.",
+                @"Program.cs(6,3): Fix whitespace formatting.",
+                @"Program.cs(7,5): Fix whitespace formatting.",
+                @"Program.cs(8,5): Fix whitespace formatting.",
+                @"Program.cs(9,7): Fix whitespace formatting.",
+                @"Program.cs(10,5): Fix whitespace formatting.",
+                @"Program.cs(11,3): Fix whitespace formatting.",
+                @"other_items\OtherClass.cs(12,2): Add final newline.",
+                @"Program.cs(12,2): Add final newline.",
             };
 
             Assert.Equal(expectedFormatLocations, formatLocations);
@@ -198,6 +210,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
                 isSolution,
                 LogLevel.Trace,
                 saveFormattedFiles: false,
+                changesAreErrors: false,
                 filesToFormat);
             var formatResult = await CodeFormatter.FormatWorkspaceAsync(formatOptions, logger, CancellationToken.None);
 

--- a/tests/Formatters/AbstractFormatterTests.cs
+++ b/tests/Formatters/AbstractFormatterTests.cs
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
             {
                 (var newFileName, var source) = sources[i];
                 var documentId = DocumentId.CreateNewId(projectId, debugName: newFileName);
-                solution = solution.AddDocument(documentId, newFileName, source);
+                solution = solution.AddDocument(documentId, newFileName, source, filePath: newFileName);
             }
 
             for (var i = 0; i < additionalFiles.Length; i++)

--- a/tests/Formatters/AbstractFormatterTests.cs
+++ b/tests/Formatters/AbstractFormatterTests.cs
@@ -84,15 +84,22 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
             TestCode = testCode;
 
             var solution = GetSolution(TestState.Sources.ToArray(), TestState.AdditionalFiles.ToArray(), TestState.AdditionalReferences.ToArray());
-            var document = solution.Projects.Single().Documents.Single();
+            var project = solution.Projects.Single();
+            var document = project.Documents.Single();
             var options = (OptionSet)await document.GetOptionsAsync();
+            var formatOptions = new FormatOptions(
+                workspaceFilePath: project.FilePath,
+                isSolution: false,
+                logLevel: LogLevel.Trace,
+                saveFormattedFiles: false,
+                filesToFormat: ImmutableHashSet.Create<string>(document.FilePath));
 
             ICodingConventionsSnapshot codingConventions = new TestCodingConventionsSnapshot(editorConfig);
             options = OptionsApplier.ApplyConventions(options, codingConventions, Language);
 
             var filesToFormat = new[] { (document, options, codingConventions) }.ToImmutableArray();
 
-            var formattedSolution = await formatter.FormatAsync(solution, filesToFormat, Logger, default);
+            var formattedSolution = await formatter.FormatAsync(solution, filesToFormat, formatOptions, Logger, default);
             var formattedDocument = formattedSolution.Projects.Single().Documents.Single();
             var formattedText = await formattedDocument.GetTextAsync();
 

--- a/tests/Formatters/AbstractFormatterTests.cs
+++ b/tests/Formatters/AbstractFormatterTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,6 +44,8 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
         protected virtual string DefaultFilePathPrefix { get; } = "Test";
 
         protected virtual string DefaultTestProjectName { get; } = "TestProject";
+
+        protected virtual string DefaultTestProjectPath => "." + Path.DirectorySeparatorChar + DefaultTestProjectName + "." + DefaultFileExt + "proj";
 
         protected virtual string DefaultFilePath => DefaultFilePathPrefix + 0 + "." + DefaultFileExt;
 
@@ -92,6 +95,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
                 isSolution: false,
                 logLevel: LogLevel.Trace,
                 saveFormattedFiles: false,
+                changesAreErrors: false,
                 filesToFormat: ImmutableHashSet.Create<string>(document.FilePath));
 
             ICodingConventionsSnapshot codingConventions = new TestCodingConventionsSnapshot(editorConfig);
@@ -216,7 +220,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
 
             var solution = CreateWorkspace()
                 .CurrentSolution
-                .AddProject(projectId, DefaultTestProjectName, DefaultTestProjectName, language)
+                .AddProject(ProjectInfo.Create(projectId, VersionStamp.Create(), DefaultTestProjectName, DefaultTestProjectName, language, filePath: DefaultTestProjectPath))
                 .WithProjectCompilationOptions(projectId, compilationOptions)
                 .AddMetadataReference(projectId, MetadataReferences.CorlibReference)
                 .AddMetadataReference(projectId, MetadataReferences.SystemReference)


### PR DESCRIPTION
Provides the necessary information for #247. Since the Roslyn whitespace formatter fixes all whitespace formatting options in one operation there are not per-rule messages for whitespace changes.

Sample output:
```
~\source\repos\format [dev/jorobich/log-format-locations ≡ +0 ~8 -0 !]> dotnet format --dry-run
  Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.
  src\Formatters\DocumentFormatter.cs(30,9): Fix whitespace formatting.
  Formatted code file 'DocumentFormatter.cs'.
  Format complete in 5337ms.
```

Fixes #90