### PR TITLE
only run given analyzers

### DIFF
--- a/src/Analyzers/ConcurrentAnalyzerRunner.cs
+++ b/src/Analyzers/ConcurrentAnalyzerRunner.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
                 ImmutableArray.Create(analyzers),
                 options: analyzerOptions,
                 cancellationToken);
-            var diagnostics = await analyzerCompilation.GetAllDiagnosticsAsync(cancellationToken);
+            var diagnostics = await analyzerCompilation.GetAnalyzerDiagnosticsAsync(cancellationToken);
             // filter diagnostics
             var filteredDiagnostics = diagnostics.Where(
                 x => !x.IsSuppressed &&


### PR DESCRIPTION
Since none of the style codefixes need compiler diagnostics to work we can reduce the amount of analysis we do.

These are the number formatting project-system on my machine

| Branch            | Time           |
| ----------------- |:--------------:|
| feature/analyzers | 81.921 seconds |
| jmarolf/perf      | 39.537 seconds |