### PR TITLE
Use EA.Format build that includes compiler support for editorconfig

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
-    <MicrosoftNETCoreCompilersPackageVersion>3.3.0-beta2-19376-01</MicrosoftNETCoreCompilersPackageVersion>
+    <MicrosoftNETCoreCompilersPackageVersion>3.3.0-beta3-19405-01</MicrosoftNETCoreCompilersPackageVersion>
   </PropertyGroup>
   <!--
     Other Dependency versions

--- a/src/dotnet-format.csproj
+++ b/src/dotnet-format.csproj
@@ -40,7 +40,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Features" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Features" Version="$(MicrosoftCodeAnalysisVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.Format" Version="3.3.0-beta2-19376-01" />
+    <PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.Format" Version="3.3.0-beta3-19405-01" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Should result in faster execution speed when running on .net core 3.0.0

Before change:
![image](https://user-images.githubusercontent.com/611219/62497113-df88c680-b78f-11e9-97c8-c8a8d4048cef.png)
After change:
![image](https://user-images.githubusercontent.com/611219/62497129-ed3e4c00-b78f-11e9-9b8d-3b8cf0a1e9fe.png)
