### PR TITLE
Add formatter for the charset .editorconfig option

### DIFF
--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -24,6 +24,7 @@ namespace Microsoft.CodeAnalysis.Tools
             new WhitespaceFormatter(),
             new FinalNewlineFormatter(),
             new EndOfLineFormatter(),
+            new CharsetFormatter(),
         }.ToImmutableArray();
 
         public static async Task<WorkspaceFormatResult> FormatWorkspaceAsync(

--- a/src/Formatters/CharsetFormatter.cs
+++ b/src/Formatters/CharsetFormatter.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.CodingConventions;
+
+namespace Microsoft.CodeAnalysis.Tools.Formatters
+{
+    internal sealed class CharsetFormatter : DocumentFormatter
+    {
+        protected override string FormatWarningDescription => Resources.Fix_file_encoding;
+
+        private static Encoding Utf8 => new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        private static Encoding Latin1 => Encoding.GetEncoding("iso-8859-1");
+
+        protected override Task<SourceText> FormatFileAsync(
+            Document document,
+            SourceText sourceText,
+            OptionSet options,
+            ICodingConventionsSnapshot codingConventions,
+            FormatOptions formatOptions,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            return Task.Run(() =>
+            {
+                if (!TryGetCharset(codingConventions, out var encoding)
+                    || sourceText.Encoding.Equals(encoding))
+                {
+                    return sourceText;
+                }
+
+                return SourceText.From(sourceText.ToString(), encoding);
+            });
+        }
+
+        private static bool TryGetCharset(ICodingConventionsSnapshot codingConventions, out Encoding encoding)
+        {
+            if (codingConventions.TryGetConventionValue("charset", out string charsetOption))
+            {
+                encoding = GetCharset(charsetOption);
+                return true;
+            }
+
+            encoding = null;
+            return false;
+        }
+
+        public static Encoding GetCharset(string charsetOption)
+        {
+            switch (charsetOption)
+            {
+                case "latin1":
+                    return Latin1;
+                case "utf-8-bom":
+                    return Encoding.UTF8; // UTF-8 with BOM Marker
+                case "utf-16be":
+                    return Encoding.BigEndianUnicode; // Big Endian with BOM Marker
+                case "utf-16le":
+                    return Encoding.Unicode; // Little Endian with BOM Marker
+                case "utf-8":
+                default:
+                    return Utf8;
+            }
+        }
+    }
+}

--- a/src/Formatters/DocumentFormatter.cs
+++ b/src/Formatters/DocumentFormatter.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
             var originalSourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
             var formattedSourceText = await FormatFileAsync(document, originalSourceText, options, codingConventions, formatOptions, logger, cancellationToken).ConfigureAwait(false);
 
-            return !formattedSourceText.ContentEquals(originalSourceText)
+            return !formattedSourceText.ContentEquals(originalSourceText) || !formattedSourceText.Encoding.Equals(originalSourceText.Encoding)
                 ? (originalSourceText, formattedSourceText)
                 : (originalSourceText, null);
         }
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
                     LogFormattingChanges(formatOptions.WorkspaceFilePath, document.FilePath, originalText, formattedText, formatOptions.ChangesAreErrors, logger);
                 }
 
-                formattedSolution = formattedSolution.WithDocumentText(document.Id, formattedText);
+                formattedSolution = formattedSolution.WithDocumentText(document.Id, formattedText, PreservationMode.PreserveIdentity);
             }
 
             return formattedSolution;

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -201,4 +201,7 @@
   <data name="Fix_whitespace_formatting" xml:space="preserve">
     <value>Fix whitespace formatting.</value>
   </data>
+  <data name="Fix_file_encoding" xml:space="preserve">
+    <value>Fix file encoding.</value>
+  </data>
 </root>

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -47,6 +47,11 @@
         <target state="new">Fix end of line marker.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_file_encoding">
+        <source>Fix file encoding.</source>
+        <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">
         <source>Fix whitespace formatting.</source>
         <target state="new">Fix whitespace formatting.</target>

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -47,6 +47,11 @@
         <target state="new">Fix end of line marker.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_file_encoding">
+        <source>Fix file encoding.</source>
+        <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">
         <source>Fix whitespace formatting.</source>
         <target state="new">Fix whitespace formatting.</target>

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -47,6 +47,11 @@
         <target state="new">Fix end of line marker.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_file_encoding">
+        <source>Fix file encoding.</source>
+        <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">
         <source>Fix whitespace formatting.</source>
         <target state="new">Fix whitespace formatting.</target>

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -47,6 +47,11 @@
         <target state="new">Fix end of line marker.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_file_encoding">
+        <source>Fix file encoding.</source>
+        <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">
         <source>Fix whitespace formatting.</source>
         <target state="new">Fix whitespace formatting.</target>

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -47,6 +47,11 @@
         <target state="new">Fix end of line marker.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_file_encoding">
+        <source>Fix file encoding.</source>
+        <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">
         <source>Fix whitespace formatting.</source>
         <target state="new">Fix whitespace formatting.</target>

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -47,6 +47,11 @@
         <target state="new">Fix end of line marker.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_file_encoding">
+        <source>Fix file encoding.</source>
+        <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">
         <source>Fix whitespace formatting.</source>
         <target state="new">Fix whitespace formatting.</target>

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -47,6 +47,11 @@
         <target state="new">Fix end of line marker.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_file_encoding">
+        <source>Fix file encoding.</source>
+        <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">
         <source>Fix whitespace formatting.</source>
         <target state="new">Fix whitespace formatting.</target>

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -47,6 +47,11 @@
         <target state="new">Fix end of line marker.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_file_encoding">
+        <source>Fix file encoding.</source>
+        <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">
         <source>Fix whitespace formatting.</source>
         <target state="new">Fix whitespace formatting.</target>

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -47,6 +47,11 @@
         <target state="new">Fix end of line marker.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_file_encoding">
+        <source>Fix file encoding.</source>
+        <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">
         <source>Fix whitespace formatting.</source>
         <target state="new">Fix whitespace formatting.</target>

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -47,6 +47,11 @@
         <target state="new">Fix end of line marker.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_file_encoding">
+        <source>Fix file encoding.</source>
+        <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">
         <source>Fix whitespace formatting.</source>
         <target state="new">Fix whitespace formatting.</target>

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -47,6 +47,11 @@
         <target state="new">Fix end of line marker.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_file_encoding">
+        <source>Fix file encoding.</source>
+        <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">
         <source>Fix whitespace formatting.</source>
         <target state="new">Fix whitespace formatting.</target>

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -47,6 +47,11 @@
         <target state="new">Fix end of line marker.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_file_encoding">
+        <source>Fix file encoding.</source>
+        <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">
         <source>Fix whitespace formatting.</source>
         <target state="new">Fix whitespace formatting.</target>

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -47,6 +47,11 @@
         <target state="new">Fix end of line marker.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Fix_file_encoding">
+        <source>Fix file encoding.</source>
+        <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">
         <source>Fix whitespace formatting.</source>
         <target state="new">Fix whitespace formatting.</target>

--- a/tests/Formatters/CharsetFormatterTests.cs
+++ b/tests/Formatters/CharsetFormatterTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Tools.Formatters;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
+{
+    public class CharsetFormatterTests : CSharpFormatterTests
+    {
+        private protected override ICodeFormatter Formatter => new CharsetFormatter();
+
+        [Theory]
+        [InlineData("latin1", "utf-8")]
+        [InlineData("latin1", "utf-8-bom")]
+        [InlineData("latin1", "utf-16be")]
+        [InlineData("latin1", "utf-16le")]
+        [InlineData("utf-8", "latin1")]
+        [InlineData("utf-8", "utf-8-bom")]
+        [InlineData("utf-8", "utf-16be")]
+        [InlineData("utf-8", "utf-16le")]
+        [InlineData("utf-8-bom", "latin1")]
+        [InlineData("utf-8-bom", "utf-8")]
+        [InlineData("utf-8-bom", "utf-16be")]
+        [InlineData("utf-8-bom", "utf-16le")]
+        [InlineData("utf-16be", "latin1")]
+        [InlineData("utf-16be", "utf-8")]
+        [InlineData("utf-16be", "utf-8-bom")]
+        [InlineData("utf-16be", "utf-16le")]
+        [InlineData("utf-16le", "latin1")]
+        [InlineData("utf-16le", "utf-8")]
+        [InlineData("utf-16le", "utf-8-bom")]
+        [InlineData("utf-16le", "utf-16be")]
+        public async Task TestCharsetWrong_CharsetFixed(string codeValue, string expectedValue)
+        {
+            var codeEncoding = CharsetFormatter.GetCharset(codeValue);
+            var expectedEncoding = CharsetFormatter.GetCharset(expectedValue);
+
+            var testCode = "class C { }";
+
+            var editorConfig = new Dictionary<string, string>()
+            {
+                ["charset"] = expectedValue,
+            };
+
+            var formattedText = await TestAsync(testCode, testCode, editorConfig, codeEncoding);
+
+            Assert.Equal(expectedEncoding, formattedText.Encoding);
+        }
+
+        [Fact]
+        public async Task TestCharsetNotSpecified_NoChange()
+        {
+            // This encoding is not supported by .editorconfig
+            var codeEncoding = Encoding.UTF32; 
+
+            var testCode = "class C { }";
+
+            var editorConfig = new Dictionary<string, string>()
+            {
+            };
+
+            var formattedText = await TestAsync(testCode, testCode, editorConfig, codeEncoding);
+
+            Assert.Equal(codeEncoding, formattedText.Encoding);
+        }
+    }
+}


### PR DESCRIPTION
`charset` support was requested by the community and should wrap up our support for the the core .editorconfig options.