### PR TITLE
Add FolderWorkspace and flag to find files by folder

### DIFF
--- a/src/FormatOptions.cs
+++ b/src/FormatOptions.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools
@@ -6,7 +8,7 @@ namespace Microsoft.CodeAnalysis.Tools
     internal class FormatOptions
     {
         public string WorkspaceFilePath { get; }
-        public bool IsSolution { get; }
+        public WorkspaceType WorkspaceType { get; }
         public LogLevel LogLevel { get; }
         public bool SaveFormattedFiles { get; }
         public bool ChangesAreErrors { get; }
@@ -14,14 +16,14 @@ namespace Microsoft.CodeAnalysis.Tools
 
         public FormatOptions(
             string workspaceFilePath,
-            bool isSolution,
+            WorkspaceType workspaceType,
             LogLevel logLevel,
             bool saveFormattedFiles,
             bool changesAreErrors,
             ImmutableHashSet<string> filesToFormat)
         {
             WorkspaceFilePath = workspaceFilePath;
-            IsSolution = isSolution;
+            WorkspaceType = workspaceType;
             LogLevel = logLevel;
             SaveFormattedFiles = saveFormattedFiles;
             ChangesAreErrors = changesAreErrors;
@@ -30,14 +32,14 @@ namespace Microsoft.CodeAnalysis.Tools
 
         public void Deconstruct(
             out string workspaceFilePath,
-            out bool isSolution,
+            out WorkspaceType workspaceType,
             out LogLevel logLevel,
             out bool saveFormattedFiles,
             out bool changesAreErrors,
             out ImmutableHashSet<string> filesToFormat)
         {
             workspaceFilePath = WorkspaceFilePath;
-            isSolution = IsSolution;
+            workspaceType = WorkspaceType;
             logLevel = LogLevel;
             saveFormattedFiles = SaveFormattedFiles;
             changesAreErrors = ChangesAreErrors;

--- a/src/Formatters/DocumentFormatter.cs
+++ b/src/Formatters/DocumentFormatter.cs
@@ -78,8 +78,6 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
             ILogger logger,
             CancellationToken cancellationToken)
         {
-            logger.LogTrace(Resources.Formatting_code_file_0, Path.GetFileName(document.FilePath));
-
             var originalSourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
             var formattedSourceText = await FormatFileAsync(document, originalSourceText, options, codingConventions, formatOptions, logger, cancellationToken).ConfigureAwait(false);
 
@@ -113,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
                     continue;
                 }
 
-                if (!formatOptions.SaveFormattedFiles)
+                if (!formatOptions.SaveFormattedFiles || formatOptions.LogLevel == LogLevel.Trace)
                 {
                     // Log formatting changes as errors when we are doing a dry-run.
                     LogFormattingChanges(formatOptions.WorkspaceFilePath, document.FilePath, originalText, formattedText, formatOptions.ChangesAreErrors, logger);

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -30,6 +30,7 @@ namespace Microsoft.CodeAnalysis.Tools
                 .RegisterWithDotnetSuggest()
                 .UseParseErrorReporting()
                 .UseExceptionHandler()
+                .AddOption(new Option(new[] { "-f", "--folder" }, Resources.The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option, new Argument<string>(() => null)))
                 .AddOption(new Option(new[] { "-w", "--workspace" }, Resources.The_solution_or_project_file_to_operate_on_If_a_file_is_not_specified_the_command_will_search_the_current_directory_for_one, new Argument<string>(() => null)))
                 .AddOption(new Option(new[] { "-v", "--verbosity" }, Resources.Set_the_verbosity_level_Allowed_values_are_quiet_minimal_normal_detailed_and_diagnostic, new Argument<string>() { Arity = ArgumentArity.ExactlyOne }.FromAmong(_verbosityLevels)))
                 .AddOption(new Option(new[] { "--dry-run" }, Resources.Format_files_but_do_not_save_changes_to_disk, new Argument<bool>()))
@@ -41,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Tools
             return await parser.InvokeAsync(args).ConfigureAwait(false);
         }
 
-        public static async Task<int> Run(string workspace, string verbosity, bool dryRun, bool check, string files, IConsole console = null)
+        public static async Task<int> Run(string folder, string workspace, string verbosity, bool dryRun, bool check, string files, IConsole console = null)
         {
             // Setup logging.
             var serviceCollection = new ServiceCollection();
@@ -65,16 +66,41 @@ namespace Microsoft.CodeAnalysis.Tools
             {
                 currentDirectory = Environment.CurrentDirectory;
 
-                var workingDirectory = Directory.GetCurrentDirectory();
-                var (isSolution, workspacePath) = MSBuildWorkspaceFinder.FindWorkspace(workingDirectory, workspace);
+                string workspaceDirectory;
+                string workspacePath;
+                WorkspaceType workspaceType;
 
-                // To ensure we get the version of MSBuild packaged with the dotnet SDK used by the
-                // workspace, use its directory as our working directory which will take into account
-                // a global.json if present.
-                var workspaceDirectory = Path.GetDirectoryName(workspacePath);
-                Environment.CurrentDirectory = workingDirectory;
+                if (!string.IsNullOrEmpty(folder) && !string.IsNullOrEmpty(workspace))
+                {
+                    logger.LogWarning(Resources.Cannot_specify_both_folder_and_workspace_options);
+                    return 1;
+                }
 
-                var filesToFormat = GetFilesToFormat(files);
+                if (!string.IsNullOrEmpty(folder))
+                {
+                    folder = Path.GetFullPath(folder, Environment.CurrentDirectory);
+                    workspacePath = folder;
+                    workspaceDirectory = workspacePath;
+                    workspaceType = WorkspaceType.Folder;
+                }
+                else
+                {
+                    var (isSolution, workspaceFilePath) = MSBuildWorkspaceFinder.FindWorkspace(currentDirectory, workspace);
+
+                    workspacePath = workspaceFilePath;
+                    workspaceType = isSolution
+                        ? WorkspaceType.Solution
+                        : WorkspaceType.Project;
+
+                    // To ensure we get the version of MSBuild packaged with the dotnet SDK used by the
+                    // workspace, use its directory as our working directory which will take into account
+                    // a global.json if present.
+                    workspaceDirectory = Path.GetDirectoryName(workspacePath);
+                }
+
+                Environment.CurrentDirectory = workspaceDirectory;
+
+                var filesToFormat = GetFilesToFormat(files, folder);
 
                 // Since we are running as a dotnet tool we should be able to find an instance of
                 // MSBuild in a .NET Core SDK.
@@ -90,7 +116,7 @@ namespace Microsoft.CodeAnalysis.Tools
 
                 var formatOptions = new FormatOptions(
                     workspacePath,
-                    isSolution,
+                    workspaceType,
                     logLevel,
                     saveFormattedFiles: !dryRun,
                     changesAreErrors: check,
@@ -164,16 +190,26 @@ namespace Microsoft.CodeAnalysis.Tools
         /// <summary>
         /// Converts a comma-separated list of relative file paths to a hashmap of full file paths.
         /// </summary>
-        internal static ImmutableHashSet<string> GetFilesToFormat(string files)
+        internal static ImmutableHashSet<string> GetFilesToFormat(string files, string folder)
         {
             if (string.IsNullOrEmpty(files))
             {
                 return ImmutableHashSet.Create<string>();
             }
 
-            return files.Split(',')
-                .Select(path => Path.GetFullPath(path, Environment.CurrentDirectory))
-                .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+            if (string.IsNullOrEmpty(folder))
+            {
+                return files.Split(',')
+                    .Select(path => Path.GetFullPath(path, Environment.CurrentDirectory))
+                    .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+            }
+            else
+            {
+                return files.Split(',')
+                    .Select(path => Path.GetFullPath(path, Environment.CurrentDirectory))
+                    .Where(path => path.StartsWith(folder))
+                    .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+            }
         }
     }
 }

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -204,4 +204,10 @@
   <data name="Fix_file_encoding" xml:space="preserve">
     <value>Fix file encoding.</value>
   </data>
+  <data name="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option" xml:space="preserve">
+    <value>The folder to operate on. Cannot be used with the `--workspace` option.</value>
+  </data>
+  <data name="Cannot_specify_both_folder_and_workspace_options" xml:space="preserve">
+    <value>Cannot specify both folder and workspace options.</value>
+  </data>
 </root>

--- a/src/WorkspaceType.cs
+++ b/src/WorkspaceType.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Tools
+{
+    internal enum WorkspaceType
+    {
+        Folder,
+        Project,
+        Solution
+    }
+}

--- a/src/Workspaces/FolderWorkspace.cs
+++ b/src/Workspaces/FolderWorkspace.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Tools.Workspaces
+{
+    internal sealed partial class FolderWorkspace : Workspace
+    {
+        private static readonly Encoding DefaultEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+        private FolderWorkspace(HostServices hostServices)
+            : base(hostServices, "Folder")
+        {
+        }
+
+        public static FolderWorkspace Create()
+        {
+            return Create(MSBuildMefHostServices.DefaultServices);
+        }
+
+        public static FolderWorkspace Create(HostServices hostServices)
+        {
+            return new FolderWorkspace(hostServices);
+        }
+
+        public async Task<Solution> OpenFolder(string folderPath, ImmutableHashSet<string> filesToInclude, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(folderPath) || !Directory.Exists(folderPath))
+            {
+                throw new ArgumentException($"Folder '{folderPath}' does not exist.", nameof(folderPath));
+            }
+
+            ClearSolution();
+
+            var solutionInfo = await FolderSolutionLoader.LoadSolutionInfoAsync(folderPath, filesToInclude, cancellationToken).ConfigureAwait(false);
+
+            OnSolutionAdded(solutionInfo);
+
+            return CurrentSolution;
+        }
+
+        public override bool CanApplyChange(ApplyChangesKind feature)
+        {
+            // Whitespace formatting should only produce document changes; no other types of changes are supported.
+            return feature == ApplyChangesKind.ChangeDocument;
+        }
+
+        protected override void ApplyDocumentTextChanged(DocumentId documentId, SourceText text)
+        {
+            var document = this.CurrentSolution.GetDocument(documentId);
+            if (document != null)
+            {
+                SaveDocumentText(documentId, document.FilePath, text, text.Encoding);
+                OnDocumentTextChanged(documentId, text, PreservationMode.PreserveValue);
+            }
+        }
+
+        private void SaveDocumentText(DocumentId id, string fullPath, SourceText newText, Encoding encoding)
+        {
+            try
+            {
+                using (var writer = new StreamWriter(fullPath, append: false, encoding))
+                {
+                    newText.Write(writer);
+                }
+            }
+            catch (IOException exception)
+            {
+                OnWorkspaceFailed(new DocumentDiagnostic(WorkspaceDiagnosticKind.Failure, exception.Message, id));
+            }
+        }
+    }
+}

--- a/src/Workspaces/FolderWorkspace_CSharpProjectLoader.cs
+++ b/src/Workspaces/FolderWorkspace_CSharpProjectLoader.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Tools.Workspaces
+{
+    internal sealed partial class FolderWorkspace : Workspace
+    {
+        private sealed class CSharpProjectLoader : ProjectLoader
+        {
+            public override string Language => LanguageNames.CSharp;
+            public override string FileExtension => ".cs";
+        }
+    }
+}

--- a/src/Workspaces/FolderWorkspace_FolderSolutionLoader.cs
+++ b/src/Workspaces/FolderWorkspace_FolderSolutionLoader.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.Tools.Workspaces
+{
+    internal sealed partial class FolderWorkspace : Workspace
+    {
+        private static class FolderSolutionLoader
+        {
+            private static ImmutableArray<ProjectLoader> ProjectLoaders
+                => ImmutableArray.Create<ProjectLoader>(new CSharpProjectLoader(), new VisualBasicProjectLoader());
+
+            public static async Task<SolutionInfo> LoadSolutionInfoAsync(string folderPath, ImmutableHashSet<string> filesToInclude, CancellationToken cancellationToken)
+            {
+                var absoluteFolderPath = Path.IsPathFullyQualified(folderPath)
+                    ? folderPath
+                    : Path.GetFullPath(folderPath, Directory.GetCurrentDirectory());
+
+                var projectInfos = ImmutableArray.CreateBuilder<ProjectInfo>(ProjectLoaders.Length);
+
+                // Create projects for each of the supported languages.
+                foreach (var loader in ProjectLoaders)
+                {
+                    var projectInfo = await loader.LoadProjectInfoAsync(folderPath, filesToInclude, cancellationToken);
+                    if (projectInfo is null)
+                    {
+                        continue;
+                    }
+
+                    projectInfos.Add(projectInfo);
+                }
+
+                // Construct workspace from loaded project infos.
+                return SolutionInfo.Create(
+                    SolutionId.CreateNewId(debugName: absoluteFolderPath),
+                    version: default,
+                    absoluteFolderPath,
+                    projectInfos);
+            }
+        }
+    }
+}

--- a/src/Workspaces/FolderWorkspace_ProjectLoader.cs
+++ b/src/Workspaces/FolderWorkspace_ProjectLoader.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.Tools.Workspaces
+{
+    internal sealed partial class FolderWorkspace : Workspace
+    {
+        private abstract class ProjectLoader
+        {
+            public abstract string Language { get; }
+            public abstract string FileExtension { get; }
+            public virtual string ProjectName => $"{Language}{FileExtension}proj";
+
+            public virtual async Task<ProjectInfo> LoadProjectInfoAsync(string folderPath, ImmutableHashSet<string> filesToInclude, CancellationToken cancellationToken)
+            {
+                var projectId = ProjectId.CreateNewId(debugName: folderPath);
+
+                var documents = await LoadDocumentInfosAsync(projectId, folderPath, FileExtension, filesToInclude);
+                if (documents.IsDefaultOrEmpty)
+                {
+                    return null;
+                }
+
+                return ProjectInfo.Create(
+                    projectId,
+                    version: default,
+                    name: ProjectName,
+                    assemblyName: folderPath,
+                    Language,
+                    filePath: folderPath,
+                    documents: documents);
+            }
+
+            private static Task<ImmutableArray<DocumentInfo>> LoadDocumentInfosAsync(ProjectId projectId, string folderPath, string fileExtension, ImmutableHashSet<string> filesToInclude)
+            {
+                return Task.Run(() =>
+                {
+                    string[] filePaths;
+                    if (filesToInclude.Count == 0)
+                    {
+                        filePaths = Directory.GetFiles(folderPath, $"*{fileExtension}", SearchOption.AllDirectories);
+                    }
+                    else
+                    {
+                        filePaths = filesToInclude.Where(
+                            filePath => filePath.EndsWith(fileExtension) && File.Exists(filePath)).ToArray();
+                    }
+
+                    if (filePaths.Length == 0)
+                    {
+                        return ImmutableArray<DocumentInfo>.Empty;
+                    }
+
+                    var documentInfos = ImmutableArray.CreateBuilder<DocumentInfo>(filePaths.Length);
+
+                    foreach (var filePath in filePaths)
+                    {
+                        var documentInfo = DocumentInfo.Create(
+                            DocumentId.CreateNewId(projectId, debugName: filePath),
+                            name: Path.GetFileName(filePath),
+                            loader: new FileTextLoader(filePath, DefaultEncoding),
+                            filePath: filePath);
+
+                        documentInfos.Add(documentInfo);
+                    }
+
+                    return documentInfos.ToImmutableArray();
+                });
+            }
+        }
+    }
+}

--- a/src/Workspaces/FolderWorkspace_VisualBasicProjectLoader.cs
+++ b/src/Workspaces/FolderWorkspace_VisualBasicProjectLoader.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Tools.Workspaces
+{
+    internal sealed partial class FolderWorkspace : Workspace
+    {
+        private sealed class VisualBasicProjectLoader : ProjectLoader
+        {
+            public override string Language => LanguageNames.VisualBasic;
+            public override string FileExtension => ".vb";
+        }
+    }
+}

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -17,6 +17,11 @@
         <target state="translated">{0} obsahuje jak soubor projektu MSBuild, tak soubor řešení. Určete, který soubor chcete použít, pomocí parametru --workspace.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_folder_and_workspace_options">
+        <source>Cannot specify both folder and workspace options.</source>
+        <target state="new">Cannot specify both folder and workspace options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>
@@ -120,6 +125,11 @@
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">Soubor {0} zřejmě není platný soubor projektu nebo řešení.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
+        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
+        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -17,6 +17,11 @@
         <target state="translated">In "{0}" wurden eine MSBuild-Projektdatei und eine Projektmappe gefunden. Geben Sie mit der Option "--workspace" an, welche verwendet werden soll.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_folder_and_workspace_options">
+        <source>Cannot specify both folder and workspace options.</source>
+        <target state="new">Cannot specify both folder and workspace options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>
@@ -120,6 +125,11 @@
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">Die Datei "{0}" ist weder ein gültiges Projekt noch eine Projektmappendatei.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
+        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
+        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Se encontró un archivo de proyecto y un archivo de solución MSBuild en "{0}". Especifique cuál debe usarse con la opción --workspace.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_folder_and_workspace_options">
+        <source>Cannot specify both folder and workspace options.</source>
+        <target state="new">Cannot specify both folder and workspace options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>
@@ -120,6 +125,11 @@
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">El archivo "{0}" no parece ser un proyecto o archivo de solución válido.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
+        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
+        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Un fichier projet et un fichier solution MSBuild ont été trouvés dans '{0}'. Spécifiez celui à utiliser avec l'option --workspace.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_folder_and_workspace_options">
+        <source>Cannot specify both folder and workspace options.</source>
+        <target state="new">Cannot specify both folder and workspace options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>
@@ -120,6 +125,11 @@
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">Le fichier '{0}' ne semble pas être un fichier projet ou solution valide.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
+        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
+        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -17,6 +17,11 @@
         <target state="translated">In '{0}' sono stati trovati sia un file di progetto che un file di soluzione MSBuild. Per specificare quello desiderato, usare l'opzione --workspace.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_folder_and_workspace_options">
+        <source>Cannot specify both folder and workspace options.</source>
+        <target state="new">Cannot specify both folder and workspace options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>
@@ -120,6 +125,11 @@
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">Il file '{0}' non sembra essere un file di progetto o di soluzione valido.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
+        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
+        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -17,6 +17,11 @@
         <target state="translated">MSBuild プロジェクト ファイルとソリューション ファイルが '{0}' で見つかりました。使用するファイルを --workspace オプションで指定してください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_folder_and_workspace_options">
+        <source>Cannot specify both folder and workspace options.</source>
+        <target state="new">Cannot specify both folder and workspace options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>
@@ -120,6 +125,11 @@
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">ファイル '{0}' が、有効なプロジェクト ファイルまたはソリューション ファイルではない可能性があります。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
+        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
+        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -17,6 +17,11 @@
         <target state="translated">'{0}'에 MSBuild 프로젝트 파일 및 솔루션 파일이 모두 있습니다. --workspace 옵션에 사용할 파일을 지정하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_folder_and_workspace_options">
+        <source>Cannot specify both folder and workspace options.</source>
+        <target state="new">Cannot specify both folder and workspace options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>
@@ -120,6 +125,11 @@
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">'{0}' 파일은 유효한 프로젝트 또는 솔루션 파일이 아닌 것 같습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
+        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
+        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -17,6 +17,11 @@
         <target state="translated">W elemencie „{0}” znaleziono zarówno plik rozwiązania, jak i plik projektu MSBuild. Określ plik do użycia za pomocą opcji --workspace.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_folder_and_workspace_options">
+        <source>Cannot specify both folder and workspace options.</source>
+        <target state="new">Cannot specify both folder and workspace options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>
@@ -120,6 +125,11 @@
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">Plik „{0}” prawdopodobnie nie jest prawidłowym plikiem projektu lub rozwiązania.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
+        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
+        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Foram encontrados um arquivo de solução e um arquivo de projeto MSBuild em '{0}'. Especifique qual usar com a opção --espaço de trabalho.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_folder_and_workspace_options">
+        <source>Cannot specify both folder and workspace options.</source>
+        <target state="new">Cannot specify both folder and workspace options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>
@@ -120,6 +125,11 @@
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">O arquivo '{0}' parece não ser um projeto válido ou o arquivo de solução.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
+        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
+        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -17,6 +17,11 @@
         <target state="translated">В "{0}" обнаружены как файл проекта, так и файл решения MSBuild. Укажите используемый файл с помощью параметра --workspace.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_folder_and_workspace_options">
+        <source>Cannot specify both folder and workspace options.</source>
+        <target state="new">Cannot specify both folder and workspace options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>
@@ -120,6 +125,11 @@
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">Файл "{0}" не является допустимым файлом проекта или решения.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
+        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
+        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -17,6 +17,11 @@
         <target state="translated">Hem bir MSBuild proje dosyası ve çözüm dosyası '{0}' içinde bulundu. Hangi--çalışma alanı seçeneği ile kullanmak için belirtin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_folder_and_workspace_options">
+        <source>Cannot specify both folder and workspace options.</source>
+        <target state="new">Cannot specify both folder and workspace options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>
@@ -120,6 +125,11 @@
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">'{0}' dosyası geçerli proje veya çözüm dosyası gibi görünmüyor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
+        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
+        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -17,6 +17,11 @@
         <target state="translated">在“{0}”中同时找到 MSBuild 项目文件和解决方案文件。请指定要将哪一个文件用于 --workspace 选项。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_folder_and_workspace_options">
+        <source>Cannot specify both folder and workspace options.</source>
+        <target state="new">Cannot specify both folder and workspace options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>
@@ -120,6 +125,11 @@
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">文件“{0}”似乎不是有效的项目或解决方案文件。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
+        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
+        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -17,6 +17,11 @@
         <target state="translated">在 '{0}' 中同時找到 MSBuild 專案檔和解決方案檔。請指定要搭配 --workspace 選項使用的檔案。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_folder_and_workspace_options">
+        <source>Cannot specify both folder and workspace options.</source>
+        <target state="new">Cannot specify both folder and workspace options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>
@@ -120,6 +125,11 @@
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">檔案 '{0}' 似乎不是有效的專案或解決方案檔。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
+        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
+        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">

--- a/tests/Formatters/AbstractFormatterTests.cs
+++ b/tests/Formatters/AbstractFormatterTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
             var document = project.Documents.Single();
             var formatOptions = new FormatOptions(
                 workspaceFilePath: project.FilePath,
-                isSolution: false,
+                workspaceType: WorkspaceType.Folder,
                 logLevel: LogLevel.Trace,
                 saveFormattedFiles: false,
                 changesAreErrors: false,

--- a/tests/ProgramTests.cs
+++ b/tests/ProgramTests.cs
@@ -38,10 +38,10 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         public void FilesFormattedDirectorySeparatorInsensitive()
         {
             var filePath = $"other_items{Path.DirectorySeparatorChar}OtherClass.cs";
-            var files = Program.GetFilesToFormat(filePath);
+            var files = Program.GetFilesToFormat(filePath, folder: null);
 
             var filePathAlt = $"other_items{Path.AltDirectorySeparatorChar}OtherClass.cs";
-            var filesAlt = Program.GetFilesToFormat(filePathAlt);
+            var filesAlt = Program.GetFilesToFormat(filePathAlt, folder: null);
 
             Assert.True(files.IsSubsetOf(filesAlt));
         }


### PR DESCRIPTION
FolderWorkspace treats code files beneath the folder as part of the Solution. This workspace wouldn't be suitable to future analyzer/codefix work since semantic information wouldn't be available, but it does suffice to provide a faster path for whitespace formatting.

Opt-in to this experience by using the `--folder` option instead of `--workspace`.

- [x] Add FolderWorkspace
- [x] Add commandline option to use FolderWorkspace
- [ ] Update readme.md