### PR TITLE
Break the integration tests into stages

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -50,5 +50,11 @@ jobs:
         _sha: "9099ad2f6e5936ecdf549f88394b5a59fa75c869"
   timeoutInMinutes: 20
   steps:
-    - script: eng\integration-test.cmd -repo '$(_repo)' -sha '$(_sha)' -testPath '$(Build.SourcesDirectory)\temp'
-      displayName: Run dotnet-format on $(_repoName)
+    - script: eng\integration-test.cmd -repo '$(_repo)' -sha '$(_sha)' -testPath '$(Build.SourcesDirectory)\temp' -stage 'prepare'
+      displayName: Prepare $(_repoName) for formatting
+
+    - script: eng\integration-test.cmd -repo '$(_repo)' -sha '$(_sha)' -testPath '$(Build.SourcesDirectory)\temp' -stage 'format-workspace'
+      displayName: Run dotnet-format on $(_repoName) solution files
+
+    - script: eng\integration-test.cmd -repo '$(_repo)' -sha '$(_sha)' -testPath '$(Build.SourcesDirectory)\temp' -stage 'format-folder'
+      displayName: Run dotnet-format on $(_repoName) repo folder


### PR DESCRIPTION
Now we can compare apples to oranges. 

"Run dotnet-format on * solutions files" uses the workspace flag and msbuild.
"Run dotnet-format on * repo folder" uses the folder flag and filesystem.

![image](https://user-images.githubusercontent.com/611219/63818069-08fec300-c8f4-11e9-8d23-29a643d89311.png)
![image](https://user-images.githubusercontent.com/611219/63817957-94c41f80-c8f3-11e9-95b8-f46f315d6e8b.png)
![image](https://user-images.githubusercontent.com/611219/63817967-9b529700-c8f3-11e9-8bb9-1b4c3ee60ad8.png)
![image](https://user-images.githubusercontent.com/611219/63817989-ad343a00-c8f3-11e9-88d2-56abe40f84a0.png)