### PR TITLE
format-379: Add `--report` command line argument to export json format report to given directory 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Options:
   --check            Terminates with a non-zero exit code if any files were formatted.
   --files            A comma separated list of relative file paths to format. All files are formatted if empty.
   --version          Display version information
+  --report           Writes a json file to the given directory. Defaults to 'format-report.json' if no filename given.
 ```
 
 Add `format` after `dotnet` and before the command arguments that you want to run:
@@ -62,6 +63,7 @@ Add `format` after `dotnet` and before the command arguments that you want to ru
 | dotnet **format** -v diag                                | Formats with very verbose logging.                                                            |
 | dotnet **format** --files Programs.cs,Utility\Logging.cs | Formats the files Program.cs and Utility\Logging.cs                                           |
 | dotnet **format** --check --dry-run                      | Formats but does not save. Returns a non-zero exit code if any files would have been changed. |
+| dotnet **format** --report &lt;report-path&gt;           | Formats and saves a json report file to the given directory.                                  |
 
 ### How To Uninstall
 

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,6 +23,7 @@
     <MicrosoftVisualStudioCodingConventionsVersion>1.1.20180503.2</MicrosoftVisualStudioCodingConventionsVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>2.9.6</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisVersion>$(MicrosoftNETCoreCompilersPackageVersion)</MicrosoftCodeAnalysisVersion>
+    <NewtonsoftJsonVerison>12.0.3</NewtonsoftJsonVerison>
   </PropertyGroup>
   <PropertyGroup>
     <DiscoverEditorConfigFiles>true</DiscoverEditorConfigFiles>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -23,7 +23,7 @@
     <MicrosoftVisualStudioCodingConventionsVersion>1.1.20180503.2</MicrosoftVisualStudioCodingConventionsVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>2.9.6</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisVersion>$(MicrosoftNETCoreCompilersPackageVersion)</MicrosoftCodeAnalysisVersion>
-    <NewtonsoftJsonVerison>12.0.3</NewtonsoftJsonVerison>
+    <SystemTextJsonVersion>4.7.0</SystemTextJsonVersion>
   </PropertyGroup>
   <PropertyGroup>
     <DiscoverEditorConfigFiles>true</DiscoverEditorConfigFiles>

--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Tools
 
                 var formattedFiles = new List<FormattedFile>();
                 var formattedSolution = await RunCodeFormattersAsync(
-                    solution, formatableFiles, options, logger, cancellationToken, formattedFiles).ConfigureAwait(false);
+                    solution, formatableFiles, options, logger, formattedFiles, cancellationToken).ConfigureAwait(false);
 
                 var formatterRanMS = workspaceStopwatch.ElapsedMilliseconds - loadWorkspaceMS - determineFilesMS;
                 logger.LogTrace(Resources.Complete_in_0_ms, formatterRanMS);
@@ -225,14 +225,14 @@ namespace Microsoft.CodeAnalysis.Tools
             ImmutableArray<(DocumentId, OptionSet, ICodingConventionsSnapshot)> formattableDocuments,
             FormatOptions options,
             ILogger logger,
-            CancellationToken cancellationToken,
-            List<FormattedFile> formattedFiles)
+            List<FormattedFile> formattedFiles,
+            CancellationToken cancellationToken)
         {
             var formattedSolution = solution;
 
             foreach (var codeFormatter in s_codeFormatters)
             {
-                formattedSolution = await codeFormatter.FormatAsync(formattedSolution, formattableDocuments, options, logger, cancellationToken, formattedFiles).ConfigureAwait(false);
+                formattedSolution = await codeFormatter.FormatAsync(formattedSolution, formattableDocuments, options, logger, formattedFiles, cancellationToken).ConfigureAwait(false);
             }
 
             return formattedSolution;

--- a/src/FileChange.cs
+++ b/src/FileChange.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Tools
+{
+    public class FileChange
+    {
+        public int LineNumber { get; set; }
+
+        public int CharNumber { get; set; }
+
+        public string FormatDescription { get; set; }
+
+        public FileChange(LinePosition changePosition, string formatDescription)
+        {
+            // LinePosition is zero based so we need to increment to report numbers people expect.
+            LineNumber = changePosition.Line + 1;
+            CharNumber = changePosition.Character + 1;
+            FormatDescription = formatDescription;
+        }
+    }
+}

--- a/src/FileChange.cs
+++ b/src/FileChange.cs
@@ -4,11 +4,11 @@ namespace Microsoft.CodeAnalysis.Tools
 {
     public class FileChange
     {
-        public int LineNumber { get; set; }
+        public int LineNumber { get; }
 
-        public int CharNumber { get; set; }
+        public int CharNumber { get; }
 
-        public string FormatDescription { get; set; }
+        public string FormatDescription { get; }
 
         public FileChange(LinePosition changePosition, string formatDescription)
         {

--- a/src/FormatOptions.cs
+++ b/src/FormatOptions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.CodeAnalysis.Tools
         public bool SaveFormattedFiles { get; }
         public bool ChangesAreErrors { get; }
         public ImmutableHashSet<string> FilesToFormat { get; }
+        public string ReportPath { get; }
 
         public FormatOptions(
             string workspaceFilePath,
@@ -20,7 +21,8 @@ namespace Microsoft.CodeAnalysis.Tools
             LogLevel logLevel,
             bool saveFormattedFiles,
             bool changesAreErrors,
-            ImmutableHashSet<string> filesToFormat)
+            ImmutableHashSet<string> filesToFormat,
+            string reportPath)
         {
             WorkspaceFilePath = workspaceFilePath;
             WorkspaceType = workspaceType;
@@ -28,6 +30,7 @@ namespace Microsoft.CodeAnalysis.Tools
             SaveFormattedFiles = saveFormattedFiles;
             ChangesAreErrors = changesAreErrors;
             FilesToFormat = filesToFormat;
+            ReportPath = reportPath;
         }
 
         public void Deconstruct(
@@ -36,7 +39,8 @@ namespace Microsoft.CodeAnalysis.Tools
             out LogLevel logLevel,
             out bool saveFormattedFiles,
             out bool changesAreErrors,
-            out ImmutableHashSet<string> filesToFormat)
+            out ImmutableHashSet<string> filesToFormat,
+            out string reportPath)
         {
             workspaceFilePath = WorkspaceFilePath;
             workspaceType = WorkspaceType;
@@ -44,6 +48,7 @@ namespace Microsoft.CodeAnalysis.Tools
             saveFormattedFiles = SaveFormattedFiles;
             changesAreErrors = ChangesAreErrors;
             filesToFormat = FilesToFormat;
+            reportPath = ReportPath;
         }
     }
 }

--- a/src/FormattedFile.cs
+++ b/src/FormattedFile.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Tools
+{
+    public class FormattedFile
+    {
+        public DocumentId DocumentId { get; set; }
+
+        public string FileName { get; set; }
+
+        public string FilePath { get; set; }
+
+        public IEnumerable<FileChange> FileChanges { get; set; }
+
+        public FormattedFile(Document document, IEnumerable<FileChange> fileChanges)
+        {
+            DocumentId = document.Id;
+            FileName = document.Name;
+            FilePath = document.FilePath;
+            FileChanges = fileChanges;
+        }
+    }
+}

--- a/src/FormattedFile.cs
+++ b/src/FormattedFile.cs
@@ -4,13 +4,13 @@ namespace Microsoft.CodeAnalysis.Tools
 {
     public class FormattedFile
     {
-        public DocumentId DocumentId { get; set; }
+        public DocumentId DocumentId { get; }
 
-        public string FileName { get; set; }
+        public string FileName { get; }
 
-        public string FilePath { get; set; }
+        public string FilePath { get; }
 
-        public IEnumerable<FileChange> FileChanges { get; set; }
+        public IEnumerable<FileChange> FileChanges { get; }
 
         public FormattedFile(Document document, IEnumerable<FileChange> fileChanges)
         {

--- a/src/Formatters/DocumentFormatter.cs
+++ b/src/Formatters/DocumentFormatter.cs
@@ -27,11 +27,11 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
             ImmutableArray<(DocumentId, OptionSet, ICodingConventionsSnapshot)> formattableDocuments,
             FormatOptions formatOptions,
             ILogger logger,
-            CancellationToken cancellationToken,
-            List<FormattedFile> formattedFiles)
+            List<FormattedFile> formattedFiles,
+            CancellationToken cancellationToken)
         {
             var formattedDocuments = FormatFiles(solution, formattableDocuments, formatOptions, logger, cancellationToken);
-            return await ApplyFileChangesAsync(solution, formattedDocuments, formatOptions, logger, cancellationToken, formattedFiles).ConfigureAwait(false);
+            return await ApplyFileChangesAsync(solution, formattedDocuments, formatOptions, logger, formattedFiles, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -96,8 +96,8 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
             ImmutableArray<(Document, Task<(SourceText originalText, SourceText formattedText)>)> formattedDocuments,
             FormatOptions formatOptions,
             ILogger logger,
-            CancellationToken cancellationToken,
-            List<FormattedFile> formattedFiles)
+            List<FormattedFile> formattedFiles,
+            CancellationToken cancellationToken)
         {
             var formattedSolution = solution;
 

--- a/src/Formatters/ICodeFormatter.cs
+++ b/src/Formatters/ICodeFormatter.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
         /// <summary>
         /// Applies formatting and returns a formatted <see cref="Solution"/>.
         /// </summary>
-        Task<Solution> FormatAsync(
+        Task<(Solution Solution, List<FormattedFile> FormattedFiles)> FormatAsync(
             Solution solution,
             ImmutableArray<(DocumentId, OptionSet, ICodingConventionsSnapshot)> formattableDocuments,
             FormatOptions options,

--- a/src/Formatters/ICodeFormatter.cs
+++ b/src/Formatters/ICodeFormatter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
             ImmutableArray<(DocumentId, OptionSet, ICodingConventionsSnapshot)> formattableDocuments,
             FormatOptions options,
             ILogger logger,
-            CancellationToken cancellationToken,
-            List<FormattedFile> formattedFiles);
+            List<FormattedFile> formattedFiles,
+            CancellationToken cancellationToken);
     }
 }

--- a/src/Formatters/ICodeFormatter.cs
+++ b/src/Formatters/ICodeFormatter.cs
@@ -15,11 +15,12 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
         /// <summary>
         /// Applies formatting and returns a formatted <see cref="Solution"/>.
         /// </summary>
-        Task<(Solution Solution, List<FormattedFile> FormattedFiles)> FormatAsync(
+        Task<Solution> FormatAsync(
             Solution solution,
             ImmutableArray<(DocumentId, OptionSet, ICodingConventionsSnapshot)> formattableDocuments,
             FormatOptions options,
             ILogger logger,
-            CancellationToken cancellationToken);
+            CancellationToken cancellationToken,
+            List<FormattedFile> formattedFiles);
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -36,13 +36,14 @@ namespace Microsoft.CodeAnalysis.Tools
                 .AddOption(new Option(new[] { "--dry-run" }, Resources.Format_files_but_do_not_save_changes_to_disk, new Argument<bool>()))
                 .AddOption(new Option(new[] { "--check" }, Resources.Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted, new Argument<bool>()))
                 .AddOption(new Option(new[] { "--files" }, Resources.A_comma_separated_list_of_relative_file_paths_to_format_All_files_are_formatted_if_empty, new Argument<string>(() => null)))
+                .AddOption(new Option(new[] { "--report" }, Resources.Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory, new Argument<string>(() => null)))
                 .UseVersionOption()
                 .Build();
 
             return await parser.InvokeAsync(args).ConfigureAwait(false);
         }
 
-        public static async Task<int> Run(string folder, string workspace, string verbosity, bool dryRun, bool check, string files, IConsole console = null)
+        public static async Task<int> Run(string folder, string workspace, string verbosity, bool dryRun, bool check, string files, string report, IConsole console = null)
         {
             // Setup logging.
             var serviceCollection = new ServiceCollection();
@@ -120,7 +121,8 @@ namespace Microsoft.CodeAnalysis.Tools
                     logLevel,
                     saveFormattedFiles: !dryRun,
                     changesAreErrors: check,
-                    filesToFormat);
+                    filesToFormat,
+                    reportPath: report);
 
                 var formatResult = await CodeFormatter.FormatWorkspaceAsync(
                     formatOptions,

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -210,4 +210,10 @@
   <data name="Cannot_specify_both_folder_and_workspace_options" xml:space="preserve">
     <value>Cannot specify both folder and workspace options.</value>
   </data>
+  <data name="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory" xml:space="preserve">
+    <value>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</value>
+  </data>
+  <data name="Writing_formatting_report_to_0" xml:space="preserve">
+    <value>Writing formatting report to: '{0}'.</value>
+  </data>
 </root>

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -211,7 +211,7 @@
     <value>Cannot specify both folder and workspace options.</value>
   </data>
   <data name="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory" xml:space="preserve">
-    <value>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</value>
+    <value>Accepts a file path, which if provided, will produce a json report in the given directory.</value>
   </data>
   <data name="Writing_formatting_report_to_0" xml:space="preserve">
     <value>Writing formatting report to: '{0}'.</value>

--- a/src/dotnet-format.csproj
+++ b/src/dotnet-format.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.CodingConventions" Version="$(MicrosoftVisualStudioCodingConventionsVersion)" Publish="true" />
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVerison)" />
 
     <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
@@ -45,7 +46,7 @@
 
   <ItemGroup>
     <None Include="..\README.md" />
-    <None Include="..\packageicon.png" Pack="true" PackagePath="\"/>
+    <None Include="..\packageicon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet-format.csproj
+++ b/src/dotnet-format.csproj
@@ -29,7 +29,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.CodingConventions" Version="$(MicrosoftVisualStudioCodingConventionsVersion)" Publish="true" />
-    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVerison)" />
 
     <PackageReference Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion)" />
@@ -38,6 +37,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
-        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
-        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <source>Accepts a file path, which if provided, will produce a json report in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_final_newline">

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
+        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_final_newline">
         <source>Add final newline.</source>
         <target state="new">Add final newline.</target>
@@ -155,6 +160,11 @@
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">
         <source>Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</source>
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Writing_formatting_report_to_0">
+        <source>Writing formatting report to: '{0}'.</source>
+        <target state="new">Writing formatting report to: '{0}'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
-        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
-        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <source>Accepts a file path, which if provided, will produce a json report in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_final_newline">

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
+        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_final_newline">
         <source>Add final newline.</source>
         <target state="new">Add final newline.</target>
@@ -155,6 +160,11 @@
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">
         <source>Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</source>
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Writing_formatting_report_to_0">
+        <source>Writing formatting report to: '{0}'.</source>
+        <target state="new">Writing formatting report to: '{0}'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
-        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
-        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <source>Accepts a file path, which if provided, will produce a json report in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_final_newline">

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
+        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_final_newline">
         <source>Add final newline.</source>
         <target state="new">Add final newline.</target>
@@ -155,6 +160,11 @@
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">
         <source>Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</source>
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Writing_formatting_report_to_0">
+        <source>Writing formatting report to: '{0}'.</source>
+        <target state="new">Writing formatting report to: '{0}'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
-        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
-        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <source>Accepts a file path, which if provided, will produce a json report in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_final_newline">

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
+        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_final_newline">
         <source>Add final newline.</source>
         <target state="new">Add final newline.</target>
@@ -155,6 +160,11 @@
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">
         <source>Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</source>
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Writing_formatting_report_to_0">
+        <source>Writing formatting report to: '{0}'.</source>
+        <target state="new">Writing formatting report to: '{0}'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
-        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
-        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <source>Accepts a file path, which if provided, will produce a json report in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_final_newline">

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
+        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_final_newline">
         <source>Add final newline.</source>
         <target state="new">Add final newline.</target>
@@ -155,6 +160,11 @@
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">
         <source>Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</source>
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Writing_formatting_report_to_0">
+        <source>Writing formatting report to: '{0}'.</source>
+        <target state="new">Writing formatting report to: '{0}'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
-        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
-        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <source>Accepts a file path, which if provided, will produce a json report in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_final_newline">

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
+        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_final_newline">
         <source>Add final newline.</source>
         <target state="new">Add final newline.</target>
@@ -155,6 +160,11 @@
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">
         <source>Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</source>
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Writing_formatting_report_to_0">
+        <source>Writing formatting report to: '{0}'.</source>
+        <target state="new">Writing formatting report to: '{0}'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
-        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
-        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <source>Accepts a file path, which if provided, will produce a json report in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_final_newline">

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
+        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_final_newline">
         <source>Add final newline.</source>
         <target state="new">Add final newline.</target>
@@ -155,6 +160,11 @@
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">
         <source>Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</source>
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Writing_formatting_report_to_0">
+        <source>Writing formatting report to: '{0}'.</source>
+        <target state="new">Writing formatting report to: '{0}'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
-        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
-        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <source>Accepts a file path, which if provided, will produce a json report in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_final_newline">

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
+        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_final_newline">
         <source>Add final newline.</source>
         <target state="new">Add final newline.</target>
@@ -155,6 +160,11 @@
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">
         <source>Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</source>
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Writing_formatting_report_to_0">
+        <source>Writing formatting report to: '{0}'.</source>
+        <target state="new">Writing formatting report to: '{0}'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
-        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
-        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <source>Accepts a file path, which if provided, will produce a json report in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_final_newline">

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
+        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_final_newline">
         <source>Add final newline.</source>
         <target state="new">Add final newline.</target>
@@ -155,6 +160,11 @@
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">
         <source>Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</source>
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Writing_formatting_report_to_0">
+        <source>Writing formatting report to: '{0}'.</source>
+        <target state="new">Writing formatting report to: '{0}'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
-        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
-        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <source>Accepts a file path, which if provided, will produce a json report in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_final_newline">

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
+        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_final_newline">
         <source>Add final newline.</source>
         <target state="new">Add final newline.</target>
@@ -155,6 +160,11 @@
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">
         <source>Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</source>
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Writing_formatting_report_to_0">
+        <source>Writing formatting report to: '{0}'.</source>
+        <target state="new">Writing formatting report to: '{0}'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
-        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
-        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <source>Accepts a file path, which if provided, will produce a json report in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_final_newline">

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
+        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_final_newline">
         <source>Add final newline.</source>
         <target state="new">Add final newline.</target>
@@ -155,6 +160,11 @@
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">
         <source>Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</source>
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Writing_formatting_report_to_0">
+        <source>Writing formatting report to: '{0}'.</source>
+        <target state="new">Writing formatting report to: '{0}'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
-        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
-        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <source>Accepts a file path, which if provided, will produce a json report in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_final_newline">

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
+        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_final_newline">
         <source>Add final newline.</source>
         <target state="new">Add final newline.</target>
@@ -155,6 +160,11 @@
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">
         <source>Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</source>
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Writing_formatting_report_to_0">
+        <source>Writing formatting report to: '{0}'.</source>
+        <target state="new">Writing formatting report to: '{0}'.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
-        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
-        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <source>Accepts a file path, which if provided, will produce a json report in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
       <trans-unit id="Add_final_newline">

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="new">A comma separated list of relative file paths to format. All files are formatted if empty.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">
+        <source>Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</source>
+        <target state="new">Accepts a file path, which if provided, will produce a `format-report.json` file in the given directory.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Add_final_newline">
         <source>Add final newline.</source>
         <target state="new">Add final newline.</target>
@@ -155,6 +160,11 @@
       <trans-unit id="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings">
         <source>Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</source>
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Writing_formatting_report_to_0">
+        <source>Writing formatting report to: '{0}'.</source>
+        <target state="new">Writing formatting report to: '{0}'.</target>
         <note />
       </trans-unit>
     </body>

--- a/tests/CodeFormatterTests.cs
+++ b/tests/CodeFormatterTests.cs
@@ -260,7 +260,8 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
                 LogLevel.Trace,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                filesToFormat);
+                filesToFormat,
+                reportPath: string.Empty);
             var formatResult = await CodeFormatter.FormatWorkspaceAsync(formatOptions, logger, CancellationToken.None);
 
             Assert.Equal(expectedExitCode, formatResult.ExitCode);

--- a/tests/Formatters/AbstractFormatterTests.cs
+++ b/tests/Formatters/AbstractFormatterTests.cs
@@ -96,19 +96,11 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
 
             var filesToFormat = await GetOnlyFileToFormatAsync(solution, editorConfig);
 
-            var formattedSolution = await Formatter.FormatAsync(solution, filesToFormat, formatOptions, Logger, default);
-            var formattedDocument = GetOnlyDocument(formattedSolution.Solution);
+            var formattedSolution = await Formatter.FormatAsync(solution, filesToFormat, formatOptions, Logger, default, new List<FormattedFile>());
+            var formattedDocument = GetOnlyDocument(formattedSolution);
             var formattedText = await formattedDocument.GetTextAsync();
 
             Assert.Equal(expectedCode, formattedText.ToString());
-
-            if (testCode != expectedCode)
-            {
-                var formattedFile = formattedSolution.FormattedFiles.Single();
-                Assert.Equal(formattedDocument.Name, formattedFile.FileName);
-                Assert.Equal(formattedDocument.FilePath, formattedFile.FilePath);
-                Assert.Equal(formattedDocument.Id, formattedFile.DocumentId);
-            }
 
             return formattedText;
         }
@@ -160,7 +152,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
         /// <param name="additionalFiles">Additional documents to include in the project.</param>
         /// <param name="additionalMetadataReferences">Additional metadata references to include in the project.</param>
         /// <returns>A solution containing a project with the specified sources and additional files.</returns>
-        private Solution GetSolution((string filename, SourceText content)[] sources, (string filename, SourceText content)[] additionalFiles, MetadataReference[] additionalMetadataReferences)
+        private protected Solution GetSolution((string filename, SourceText content)[] sources, (string filename, SourceText content)[] additionalFiles, MetadataReference[] additionalMetadataReferences)
         {
             var project = CreateProject(sources, additionalFiles, additionalMetadataReferences, Language);
             return project.Solution;

--- a/tests/Formatters/AbstractFormatterTests.cs
+++ b/tests/Formatters/AbstractFormatterTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
 
             var filesToFormat = await GetOnlyFileToFormatAsync(solution, editorConfig);
 
-            var formattedSolution = await Formatter.FormatAsync(solution, filesToFormat, formatOptions, Logger, default, new List<FormattedFile>());
+            var formattedSolution = await Formatter.FormatAsync(solution, filesToFormat, formatOptions, Logger, new List<FormattedFile>(), default);
             var formattedDocument = GetOnlyDocument(formattedSolution);
             var formattedText = await formattedDocument.GetTextAsync();
 

--- a/tests/Formatters/AbstractFormatterTests.cs
+++ b/tests/Formatters/AbstractFormatterTests.cs
@@ -91,15 +91,24 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
                 logLevel: LogLevel.Trace,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                filesToFormat: ImmutableHashSet.Create(document.FilePath));
+                filesToFormat: ImmutableHashSet.Create(document.FilePath),
+                reportPath: string.Empty);
 
             var filesToFormat = await GetOnlyFileToFormatAsync(solution, editorConfig);
 
             var formattedSolution = await Formatter.FormatAsync(solution, filesToFormat, formatOptions, Logger, default);
-            var formattedDocument = GetOnlyDocument(formattedSolution);
+            var formattedDocument = GetOnlyDocument(formattedSolution.Solution);
             var formattedText = await formattedDocument.GetTextAsync();
 
             Assert.Equal(expectedCode, formattedText.ToString());
+
+            if (testCode != expectedCode)
+            {
+                var formattedFile = formattedSolution.FormattedFiles.Single();
+                Assert.Equal(formattedDocument.Name, formattedFile.FileName);
+                Assert.Equal(formattedDocument.FilePath, formattedFile.FilePath);
+                Assert.Equal(formattedDocument.Id, formattedFile.DocumentId);
+            }
 
             return formattedText;
         }

--- a/tests/Formatters/FormattedFilesTests.cs
+++ b/tests/Formatters/FormattedFilesTests.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Tools.Formatters;
+using Microsoft.CodeAnalysis.Tools.Tests.Utilities;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
+{
+    public class FormattedFilesTests : CSharpFormatterTests
+    {
+        private protected override ICodeFormatter Formatter => new FinalNewlineFormatter();
+
+        [Fact]
+        public async Task ReturnsItem_WhenFileFormatted()
+        {
+            var testCode = "class C\n{\n}";
+
+            var result = await TestFormattedFiles(testCode);
+
+            Assert.Single(result);
+        }
+
+        [Fact]
+        public async Task ReturnsEmptyList_WhenNoFilesFormatted()
+        {
+            var testCode = "class C\n{\n}\n";
+
+            var result = await TestFormattedFiles(testCode);
+
+            Assert.Empty(result);
+        }
+
+        private async Task<List<FormattedFile>> TestFormattedFiles(string testCode)
+        {
+            var text = SourceText.From(testCode, Encoding.UTF8);
+            TestState.Sources.Add(text);
+
+            var solution = GetSolution(TestState.Sources.ToArray(), TestState.AdditionalFiles.ToArray(), TestState.AdditionalReferences.ToArray());
+            var project = solution.Projects.Single();
+            var document = project.Documents.Single();
+            var formatOptions = new FormatOptions(
+                workspaceFilePath: project.FilePath,
+                workspaceType: WorkspaceType.Folder,
+                logLevel: LogLevel.Trace,
+                saveFormattedFiles: false,
+                changesAreErrors: false,
+                filesToFormat: ImmutableHashSet.Create(document.FilePath),
+                reportPath: string.Empty);
+            var editorConfig = new Dictionary<string, string>()
+            {
+                ["insert_final_newline"] = "true",
+                ["end_of_line"] = "lf",
+            };
+
+            var filesToFormat = await GetOnlyFileToFormatAsync(solution, editorConfig);
+
+            var formattedFiles = new List<FormattedFile>();
+            await Formatter.FormatAsync(solution, filesToFormat, formatOptions, new TestLogger(), default, formattedFiles);
+
+            return formattedFiles;
+        }
+    }
+}

--- a/tests/Formatters/FormattedFilesTests.cs
+++ b/tests/Formatters/FormattedFilesTests.cs
@@ -15,6 +15,12 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
     {
         private protected override ICodeFormatter Formatter => new FinalNewlineFormatter();
 
+        private readonly Dictionary<string, string> editorConfig = new Dictionary<string, string>()
+        {
+            ["insert_final_newline"] = "true",
+            ["end_of_line"] = "lf",
+        };
+
         [Fact]
         public async Task ReturnsItem_WhenFileFormatted()
         {
@@ -51,16 +57,11 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
                 changesAreErrors: false,
                 filesToFormat: ImmutableHashSet.Create(document.FilePath),
                 reportPath: string.Empty);
-            var editorConfig = new Dictionary<string, string>()
-            {
-                ["insert_final_newline"] = "true",
-                ["end_of_line"] = "lf",
-            };
 
             var filesToFormat = await GetOnlyFileToFormatAsync(solution, editorConfig);
 
             var formattedFiles = new List<FormattedFile>();
-            await Formatter.FormatAsync(solution, filesToFormat, formatOptions, new TestLogger(), default, formattedFiles);
+            await Formatter.FormatAsync(solution, filesToFormat, formatOptions, new TestLogger(), formattedFiles, default);
 
             return formattedFiles;
         }


### PR DESCRIPTION
PR for [this task](https://github.com/dotnet/format/issues/379). I diverged a tad from the original ask (generate a report when the `--dry-run` is provided) and decided that this would probably be useful in both normal and `--dry-run` modes. Also allowed the user to provide the output directory for the report, which I felt would be handy too (e.g. publishing it to a report viewer in Jenkins).