### PR TITLE
Combine --check and --dry-run into a single option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Options:
                      the current directory for one.
   --verbosity, -v    Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and
                      diag[nostic]
-  --dry-run          Format files, but do not save changes to disk.
-  --check            Terminates with a non-zero exit code if any files were formatted.
+  --check, --dry-run Formats files without saving changes to disk. Terminates with a non-zero exit code if any files
+                     were formatted.
   --include, --files A comma separated list of relative file or folder paths to include in formatting. All files are
                      formatted if empty.
   --exclude          A comma separated list of relative file or folder paths to exclude from formatting.
@@ -70,7 +70,7 @@ Add `format` after `dotnet` and before the command arguments that you want to ru
 | dotnet **format** -w &lt;workspace&gt;                     | Formats a specific project or solution.                                                       |
 | dotnet **format** -v diag                                  | Formats with very verbose logging.                                                            |
 | dotnet **format** --include Programs.cs,Utility\Logging.cs | Formats the files Program.cs and Utility\Logging.cs                                           |
-| dotnet **format** --check --dry-run                        | Formats but does not save. Returns a non-zero exit code if any files would have been changed. |
+| dotnet **format** --check                                  | Formats but does not save. Returns a non-zero exit code if any files would have been changed. |
 | dotnet **format** --report &lt;report-path&gt;             | Formats and saves a json report file to the given directory.                                  |
 
 ### How To Uninstall

--- a/eng/format-verifier.ps1
+++ b/eng/format-verifier.ps1
@@ -58,12 +58,13 @@ try {
                 Write-Output "$(Get-Date) - $solutionFile - Formatting Workspace"
                 $output = dotnet.exe run -p "$currentLocation\src\dotnet-format.csproj" -c Release -- -w $solution -v d --dry-run | Out-String
                 Write-Output $output.TrimEnd()
-                
-                if ($LastExitCode -ne 0) {
+
+                # Ignore CheckFailedExitCode since we don't expect these repos to be properly formatted.
+                if ($LastExitCode -ne 0 -and $LastExitCode -ne 2) {
                     Write-Output "$(Get-Date) - Formatting failed with error code $LastExitCode."
                     exit -1
                 }
-                
+
                 if (($output -notmatch "(?m)Formatted \d+ of (\d+) files") -or ($Matches[1] -eq "0")) {
                     Write-Output "$(Get-Date) - No files found for solution."
                     exit -1
@@ -78,12 +79,12 @@ try {
         Write-Output "$(Get-Date) - $folderName - Formatting Folder"
         $output = dotnet.exe run -p "$currentLocation\src\dotnet-format.csproj" -c Release -- -f $repoPath -v d --dry-run | Out-String
         Write-Output $output.TrimEnd()
-        
+
         if ($LastExitCode -ne 0) {
             Write-Output "$(Get-Date) - Formatting failed with error code $LastExitCode."
             exit -1
         }
-        
+
         if (($output -notmatch "(?m)Formatted \d+ of (\d+) files") -or ($Matches[1] -eq "0")) {
             Write-Output "$(Get-Date) - No files found for solution."
             exit -1

--- a/eng/format-verifier.ps1
+++ b/eng/format-verifier.ps1
@@ -80,7 +80,8 @@ try {
         $output = dotnet.exe run -p "$currentLocation\src\dotnet-format.csproj" -c Release -- -f $repoPath -v d --dry-run | Out-String
         Write-Output $output.TrimEnd()
 
-        if ($LastExitCode -ne 0) {
+        # Ignore CheckFailedExitCode since we don't expect these repos to be properly formatted.
+        if ($LastExitCode -ne 0 -and $LastExitCode -ne 2) {
             Write-Output "$(Get-Date) - Formatting failed with error code $LastExitCode."
             exit -1
         }
@@ -92,6 +93,8 @@ try {
 
         Write-Output "$(Get-Date) - $folderName - Complete"
     }
+
+    exit 0
 }
 catch {
     exit -1

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -33,8 +33,7 @@ namespace Microsoft.CodeAnalysis.Tools
                 .AddOption(new Option(new[] { "--folder", "-f" }, Resources.The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option, new Argument<string>(() => null)))
                 .AddOption(new Option(new[] { "--workspace", "-w" }, Resources.The_solution_or_project_file_to_operate_on_If_a_file_is_not_specified_the_command_will_search_the_current_directory_for_one, new Argument<string>(() => null)))
                 .AddOption(new Option(new[] { "--verbosity", "-v" }, Resources.Set_the_verbosity_level_Allowed_values_are_quiet_minimal_normal_detailed_and_diagnostic, new Argument<string>() { Arity = ArgumentArity.ExactlyOne }.FromAmong(_verbosityLevels)))
-                .AddOption(new Option(new[] { "--dry-run" }, Resources.Format_files_but_do_not_save_changes_to_disk, new Argument<bool>()))
-                .AddOption(new Option(new[] { "--check" }, Resources.Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted, new Argument<bool>()))
+                .AddOption(new Option(new[] { "--check", "--dry-run" }, Resources.Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted, new Argument<bool>()))
                 .AddOption(new Option(new[] { "--include", "--files" }, Resources.A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty, new Argument<string>(() => null)))
                 .AddOption(new Option(new[] { "--exclude" }, Resources.A_comma_separated_list_of_relative_file_or_folder_paths_to_exclude_from_formatting, new Argument<string>(() => null)))
                 .AddOption(new Option(new[] { "--report" }, Resources.Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory, new Argument<string>(() => null)))
@@ -44,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Tools
             return await parser.InvokeAsync(args).ConfigureAwait(false);
         }
 
-        public static async Task<int> Run(string folder, string workspace, string verbosity, bool dryRun, bool check, string include, string exclude, string report, IConsole console = null)
+        public static async Task<int> Run(string folder, string workspace, string verbosity, bool check, string include, string exclude, string report, IConsole console = null)
         {
             // Setup logging.
             var serviceCollection = new ServiceCollection();
@@ -121,7 +120,7 @@ namespace Microsoft.CodeAnalysis.Tools
                     workspacePath,
                     workspaceType,
                     logLevel,
-                    saveFormattedFiles: !dryRun,
+                    saveFormattedFiles: !check,
                     changesAreErrors: check,
                     pathsToInclude,
                     pathsToExclude,

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -19,8 +19,8 @@ namespace Microsoft.CodeAnalysis.Tools
     internal class Program
     {
         private static readonly string[] _verbosityLevels = new[] { "q", "quiet", "m", "minimal", "n", "normal", "d", "detailed", "diag", "diagnostic" };
-        private const int ExceptionExitCode = 1;
-        private const int CheckFailedExitCode = 2;
+        internal const int UnhandledExceptionExitCode = 1;
+        internal const int CheckFailedExitCode = 2;
 
         private static async Task<int> Main(string[] args)
         {
@@ -138,11 +138,11 @@ namespace Microsoft.CodeAnalysis.Tools
             catch (FileNotFoundException fex)
             {
                 logger.LogError(fex.Message);
-                return ExceptionExitCode;
+                return UnhandledExceptionExitCode;
             }
             catch (OperationCanceledException)
             {
-                return ExceptionExitCode;
+                return UnhandledExceptionExitCode;
             }
             finally
             {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -19,6 +19,8 @@ namespace Microsoft.CodeAnalysis.Tools
     internal class Program
     {
         private static readonly string[] _verbosityLevels = new[] { "q", "quiet", "m", "minimal", "n", "normal", "d", "detailed", "diag", "diagnostic" };
+        private const int ExceptionExitCode = 1;
+        private const int CheckFailedExitCode = 2;
 
         private static async Task<int> Main(string[] args)
         {
@@ -136,11 +138,11 @@ namespace Microsoft.CodeAnalysis.Tools
             catch (FileNotFoundException fex)
             {
                 logger.LogError(fex.Message);
-                return 1;
+                return ExceptionExitCode;
             }
             catch (OperationCanceledException)
             {
-                return 1;
+                return ExceptionExitCode;
             }
             finally
             {
@@ -158,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Tools
                 return formatResult.ExitCode;
             }
 
-            return formatResult.FilesFormatted == 0 ? 0 : 1;
+            return formatResult.FilesFormatted == 0 ? 0 : CheckFailedExitCode;
         }
 
         internal static LogLevel GetLogLevel(string verbosity)

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -171,8 +171,8 @@
   <data name="Format_files_but_do_not_save_changes_to_disk" xml:space="preserve">
     <value>Format files, but do not save changes to disk.</value>
   </data>
-  <data name="Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted" xml:space="preserve">
-    <value>Terminates with a non-zero exit code if any files were formatted.</value>
+  <data name="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted" xml:space="preserve">
+    <value>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</value>
   </data>
   <data name="A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty" xml:space="preserve">
     <value>A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</value>

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Soubory se naformátují, ale změny se neuloží na disk.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+        <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
+        <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatted_0_of_1_files">
         <source>Formatted {0} of {1} files.</source>
         <target state="new">Formatted {0} of {1} files.</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Skipping_referenced_project_0">
         <source>Skipping referenced project '{0}'.</source>
         <target state="translated">Přeskočí se odkazovaný projekt {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
-        <source>Terminates with a non-zero exit code if any files were formatted.</source>
-        <target state="new">Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Dateien formatieren, Änderungen aber nicht auf Festplatte speichern.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+        <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
+        <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatted_0_of_1_files">
         <source>Formatted {0} of {1} files.</source>
         <target state="new">Formatted {0} of {1} files.</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Skipping_referenced_project_0">
         <source>Skipping referenced project '{0}'.</source>
         <target state="translated">Überspringen von referenziertem Projekt "{0}".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
-        <source>Terminates with a non-zero exit code if any files were formatted.</source>
-        <target state="new">Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Formato de archivos, pero no guardar los cambios al disco.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+        <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
+        <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatted_0_of_1_files">
         <source>Formatted {0} of {1} files.</source>
         <target state="new">Formatted {0} of {1} files.</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Skipping_referenced_project_0">
         <source>Skipping referenced project '{0}'.</source>
         <target state="translated">Omitiendo projecto al que se hace referencia "{0}".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
-        <source>Terminates with a non-zero exit code if any files were formatted.</source>
-        <target state="new">Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Mettez en forme les fichiers, mais n'enregistrez pas les changements sur le disque.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+        <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
+        <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatted_0_of_1_files">
         <source>Formatted {0} of {1} files.</source>
         <target state="new">Formatted {0} of {1} files.</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Skipping_referenced_project_0">
         <source>Skipping referenced project '{0}'.</source>
         <target state="translated">Saut du projet référencé '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
-        <source>Terminates with a non-zero exit code if any files were formatted.</source>
-        <target state="new">Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Formatta i file, ma non salvare le modifiche sul disco.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+        <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
+        <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatted_0_of_1_files">
         <source>Formatted {0} of {1} files.</source>
         <target state="new">Formatted {0} of {1} files.</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Skipping_referenced_project_0">
         <source>Skipping referenced project '{0}'.</source>
         <target state="translated">Il progetto di riferimento '{0}' verrà ignorato.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
-        <source>Terminates with a non-zero exit code if any files were formatted.</source>
-        <target state="new">Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -82,6 +82,11 @@
         <target state="translated">ファイルを書式設定しますが、変更をディスクに保存しません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+        <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
+        <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatted_0_of_1_files">
         <source>Formatted {0} of {1} files.</source>
         <target state="new">Formatted {0} of {1} files.</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Skipping_referenced_project_0">
         <source>Skipping referenced project '{0}'.</source>
         <target state="translated">参照プロジェクト '{0}' をスキップしています。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
-        <source>Terminates with a non-zero exit code if any files were formatted.</source>
-        <target state="new">Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -82,6 +82,11 @@
         <target state="translated">파일의 형식을 지정하지만 변경 내용을 디스크에 저장하지 않습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+        <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
+        <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatted_0_of_1_files">
         <source>Formatted {0} of {1} files.</source>
         <target state="new">Formatted {0} of {1} files.</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Skipping_referenced_project_0">
         <source>Skipping referenced project '{0}'.</source>
         <target state="translated">참조된 프로젝트 '{0}'을(를) 건너뜁니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
-        <source>Terminates with a non-zero exit code if any files were formatted.</source>
-        <target state="new">Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Formatuj pliki, ale nie zapisuj zmian na dysku.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+        <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
+        <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatted_0_of_1_files">
         <source>Formatted {0} of {1} files.</source>
         <target state="new">Formatted {0} of {1} files.</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Skipping_referenced_project_0">
         <source>Skipping referenced project '{0}'.</source>
         <target state="translated">Pomijanie przywoływanego projektu „{0}”.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
-        <source>Terminates with a non-zero exit code if any files were formatted.</source>
-        <target state="new">Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Arquivos de formato, mas não salva as alterações para o disco.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+        <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
+        <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatted_0_of_1_files">
         <source>Formatted {0} of {1} files.</source>
         <target state="new">Formatted {0} of {1} files.</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Skipping_referenced_project_0">
         <source>Skipping referenced project '{0}'.</source>
         <target state="translated">Ignorando o projeto referenciado '{0}'.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
-        <source>Terminates with a non-zero exit code if any files were formatted.</source>
-        <target state="new">Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Форматировать файлы без сохранения изменений на диск.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+        <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
+        <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatted_0_of_1_files">
         <source>Formatted {0} of {1} files.</source>
         <target state="new">Formatted {0} of {1} files.</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Skipping_referenced_project_0">
         <source>Skipping referenced project '{0}'.</source>
         <target state="translated">Пропуск указанного проекта "{0}".</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
-        <source>Terminates with a non-zero exit code if any files were formatted.</source>
-        <target state="new">Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -82,6 +82,11 @@
         <target state="translated">Dosyaları biçimlendir, ancak değişiklikleri diske kaydetme.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+        <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
+        <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatted_0_of_1_files">
         <source>Formatted {0} of {1} files.</source>
         <target state="new">Formatted {0} of {1} files.</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Skipping_referenced_project_0">
         <source>Skipping referenced project '{0}'.</source>
         <target state="translated">Atlama projesi '{0}' başvuru.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
-        <source>Terminates with a non-zero exit code if any files were formatted.</source>
-        <target state="new">Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -82,6 +82,11 @@
         <target state="translated">格式化文件, 但不将更改保存到磁盘。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+        <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
+        <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatted_0_of_1_files">
         <source>Formatted {0} of {1} files.</source>
         <target state="new">Formatted {0} of {1} files.</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Skipping_referenced_project_0">
         <source>Skipping referenced project '{0}'.</source>
         <target state="translated">正在跳过引用的项目“{0}”。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
-        <source>Terminates with a non-zero exit code if any files were formatted.</source>
-        <target state="new">Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -82,6 +82,11 @@
         <target state="translated">將檔案格式化，但不儲存變更到磁碟。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+        <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
+        <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Formatted_0_of_1_files">
         <source>Formatted {0} of {1} files.</source>
         <target state="new">Formatted {0} of {1} files.</target>
@@ -125,11 +130,6 @@
       <trans-unit id="Skipping_referenced_project_0">
         <source>Skipping referenced project '{0}'.</source>
         <target state="translated">跳過參考的專案 '{0}’。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
-        <source>Terminates with a non-zero exit code if any files were formatted.</source>
-        <target state="new">Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">

--- a/tests/ProgramTests.cs
+++ b/tests/ProgramTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
             var formatResult = new WorkspaceFormatResult(filesFormatted: 1, fileCount: 0, exitCode: 0);
             var exitCode = Program.GetExitCode(formatResult, check: true);
 
-            Assert.Equal(1, exitCode);
+            Assert.Equal(Program.CheckFailedExitCode, exitCode);
         }
 
         [Fact]


### PR DESCRIPTION
The use case for `--check` (CI Validation) also uses `--dry-run`. Use cases for `--dry-run` could ignore exit code if formatting changes are found.

Considers `--check` as the canonical flag and `--dry-run` as an alias.

