### PR TITLE
Use space-separated paths instead of comma-separated

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Add `format` after `dotnet` and before the command arguments that you want to ru
 | dotnet **format** -f &lt;folder&gt;                        | Formats a particular folder and subfolders.                                                   |
 | dotnet **format** -w &lt;workspace&gt;                     | Formats a specific project or solution.                                                       |
 | dotnet **format** -v diag                                  | Formats with very verbose logging.                                                            |
-| dotnet **format** --include Programs.cs,Utility\Logging.cs | Formats the files Program.cs and Utility\Logging.cs                                           |
+| dotnet **format** --include Programs.cs Utility\Logging.cs | Formats the files Program.cs and Utility\Logging.cs                                           |
 | dotnet **format** --check                                  | Formats but does not save. Returns a non-zero exit code if any files would have been changed. |
 | dotnet **format** --report &lt;report-path&gt;             | Formats and saves a json report file to the given directory.                                  |
 

--- a/README.md
+++ b/README.md
@@ -42,23 +42,19 @@ dotnet tool install -g dotnet-format --version 4.0.111308 --add-source https://d
 
 By default `dotnet-format` will look in the current directory for a project or solution file and use that as the workspace to format. If more than one project or solution file is present in the current directory you will need to specify the workspace to format using the `-w` or `-f` options. You can control how verbose the output will be by using the `-v` option.
 
-```
+```sh
 Usage:
   dotnet-format [options]
 
 Options:
-  --folder, -f       The folder to operate on. Cannot be used with the `--workspace` option.
-  --workspace, -w    The solution or project file to operate on. If a file is not specified, the command will search
-                     the current directory for one.
-  --include          A comma separated list of relative file or folder paths to include in formatting. All files are
-                     formatted if empty.
-  --exclude          A comma separated list of relative file or folder paths to exclude from formatting.
-  --check            Formats files without saving changes to disk. Terminates with a non-zero exit code if any files
-                     were formatted.
-  --report           Writes a json file to the given directory. Defaults to 'format-report.json' if no filename given.
-  --verbosity, -v    Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and
-                     diag[nostic]
-  --version          Display version information
+  -f, --folder <FOLDER>           The folder to operate on. Cannot be used with the `--workspace` option.
+  -w, --workspace <WORKSPACE>     The solution or project file to operate on. If a file is not specified, the command will search the current directory for one.
+  --files, --include <INCLUDE>    A list of relative file or folder paths to include in formatting. All files are formatted if empty.
+  --exclude <EXCLUDE>             A list of relative file or folder paths to exclude from formatting.
+  --check, --dry-run <CHECK>      Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.
+  --report <REPORT>               Accepts a file path, which if provided, will produce a json report in the given directory.
+  -v, --verbosity <VERBOSITY>     Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]
+  --version                       Display version information
 ```
 
 Add `format` after `dotnet` and before the command arguments that you want to run:

--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Tools
                     foreach (var changedDocumentId in projectChanges.GetChangedDocuments())
                     {
                         var changedDocument = solution.GetDocument(changedDocumentId);
-                        logger.LogInformation(Resources.Formatted_code_file_0, Path.GetFileName(changedDocument.FilePath));
+                        logger.LogInformation(Resources.Formatted_code_file_0, changedDocument.FilePath);
                         filesFormatted++;
                     }
                 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -35,11 +35,11 @@ namespace Microsoft.CodeAnalysis.Tools
                 },
                 new Option(new[] { "--include", "--files" }, Resources.A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty)
                 {
-                    Argument = new Argument<string>(() => null)
+                    Argument = new Argument<string[]>(() => null)
                 },
                 new Option(new[] { "--exclude" }, Resources.A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting)
                 {
-                    Argument = new Argument<string>(() => null)
+                    Argument = new Argument<string[]>(() => null)
                 },
                 new Option(new[] { "--check", "--dry-run" }, Resources.Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted)
                 {

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -174,8 +174,8 @@
   <data name="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted" xml:space="preserve">
     <value>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</value>
   </data>
-  <data name="A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty" xml:space="preserve">
-    <value>A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</value>
+  <data name="A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty" xml:space="preserve">
+    <value>A list of relative file or folder paths to include in formatting. All files are formatted if empty.</value>
   </data>
   <data name="Formatted_code_file_0" xml:space="preserve">
     <value>Formatted code file '{0}'.</value>
@@ -216,7 +216,7 @@
   <data name="Writing_formatting_report_to_0" xml:space="preserve">
     <value>Writing formatting report to: '{0}'.</value>
   </data>
-  <data name="A_comma_separated_list_of_relative_file_or_folder_paths_to_exclude_from_formatting" xml:space="preserve">
-    <value>A comma separated list of relative file or folder paths to exclude from formatting.</value>
+  <data name="A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting" xml:space="preserve">
+    <value>A list of relative file or folder paths to exclude from formatting.</value>
   </data>
 </root>

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -2,14 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Resources.resx">
     <body>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
-        <source>A comma separated list of relative file or folder paths to exclude from formatting.</source>
-        <target state="new">A comma separated list of relative file or folder paths to exclude from formatting.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
+        <source>A list of relative file or folder paths to exclude from formatting.</source>
+        <target state="new">A list of relative file or folder paths to exclude from formatting.</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
-        <source>A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
-        <target state="new">A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
+        <source>A list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
+        <target state="new">A list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -2,14 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Resources.resx">
     <body>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
-        <source>A comma separated list of relative file or folder paths to exclude from formatting.</source>
-        <target state="new">A comma separated list of relative file or folder paths to exclude from formatting.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
+        <source>A list of relative file or folder paths to exclude from formatting.</source>
+        <target state="new">A list of relative file or folder paths to exclude from formatting.</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
-        <source>A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
-        <target state="new">A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
+        <source>A list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
+        <target state="new">A list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -2,14 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Resources.resx">
     <body>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
-        <source>A comma separated list of relative file or folder paths to exclude from formatting.</source>
-        <target state="new">A comma separated list of relative file or folder paths to exclude from formatting.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
+        <source>A list of relative file or folder paths to exclude from formatting.</source>
+        <target state="new">A list of relative file or folder paths to exclude from formatting.</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
-        <source>A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
-        <target state="new">A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
+        <source>A list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
+        <target state="new">A list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -2,14 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Resources.resx">
     <body>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
-        <source>A comma separated list of relative file or folder paths to exclude from formatting.</source>
-        <target state="new">A comma separated list of relative file or folder paths to exclude from formatting.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
+        <source>A list of relative file or folder paths to exclude from formatting.</source>
+        <target state="new">A list of relative file or folder paths to exclude from formatting.</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
-        <source>A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
-        <target state="new">A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
+        <source>A list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
+        <target state="new">A list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -2,14 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Resources.resx">
     <body>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
-        <source>A comma separated list of relative file or folder paths to exclude from formatting.</source>
-        <target state="new">A comma separated list of relative file or folder paths to exclude from formatting.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
+        <source>A list of relative file or folder paths to exclude from formatting.</source>
+        <target state="new">A list of relative file or folder paths to exclude from formatting.</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
-        <source>A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
-        <target state="new">A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
+        <source>A list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
+        <target state="new">A list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -2,14 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Resources.resx">
     <body>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
-        <source>A comma separated list of relative file or folder paths to exclude from formatting.</source>
-        <target state="new">A comma separated list of relative file or folder paths to exclude from formatting.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
+        <source>A list of relative file or folder paths to exclude from formatting.</source>
+        <target state="new">A list of relative file or folder paths to exclude from formatting.</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
-        <source>A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
-        <target state="new">A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
+        <source>A list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
+        <target state="new">A list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -2,14 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Resources.resx">
     <body>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
-        <source>A comma separated list of relative file or folder paths to exclude from formatting.</source>
-        <target state="new">A comma separated list of relative file or folder paths to exclude from formatting.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
+        <source>A list of relative file or folder paths to exclude from formatting.</source>
+        <target state="new">A list of relative file or folder paths to exclude from formatting.</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
-        <source>A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
-        <target state="new">A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
+        <source>A list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
+        <target state="new">A list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -2,14 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Resources.resx">
     <body>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
-        <source>A comma separated list of relative file or folder paths to exclude from formatting.</source>
-        <target state="new">A comma separated list of relative file or folder paths to exclude from formatting.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
+        <source>A list of relative file or folder paths to exclude from formatting.</source>
+        <target state="new">A list of relative file or folder paths to exclude from formatting.</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
-        <source>A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
-        <target state="new">A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
+        <source>A list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
+        <target state="new">A list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -2,14 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Resources.resx">
     <body>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
-        <source>A comma separated list of relative file or folder paths to exclude from formatting.</source>
-        <target state="new">A comma separated list of relative file or folder paths to exclude from formatting.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
+        <source>A list of relative file or folder paths to exclude from formatting.</source>
+        <target state="new">A list of relative file or folder paths to exclude from formatting.</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
-        <source>A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
-        <target state="new">A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
+        <source>A list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
+        <target state="new">A list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -2,14 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Resources.resx">
     <body>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
-        <source>A comma separated list of relative file or folder paths to exclude from formatting.</source>
-        <target state="new">A comma separated list of relative file or folder paths to exclude from formatting.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
+        <source>A list of relative file or folder paths to exclude from formatting.</source>
+        <target state="new">A list of relative file or folder paths to exclude from formatting.</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
-        <source>A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
-        <target state="new">A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
+        <source>A list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
+        <target state="new">A list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -2,14 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Resources.resx">
     <body>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
-        <source>A comma separated list of relative file or folder paths to exclude from formatting.</source>
-        <target state="new">A comma separated list of relative file or folder paths to exclude from formatting.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
+        <source>A list of relative file or folder paths to exclude from formatting.</source>
+        <target state="new">A list of relative file or folder paths to exclude from formatting.</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
-        <source>A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
-        <target state="new">A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
+        <source>A list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
+        <target state="new">A list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -2,14 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Resources.resx">
     <body>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
-        <source>A comma separated list of relative file or folder paths to exclude from formatting.</source>
-        <target state="new">A comma separated list of relative file or folder paths to exclude from formatting.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
+        <source>A list of relative file or folder paths to exclude from formatting.</source>
+        <target state="new">A list of relative file or folder paths to exclude from formatting.</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
-        <source>A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
-        <target state="new">A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
+        <source>A list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
+        <target state="new">A list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -2,14 +2,14 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Resources.resx">
     <body>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
-        <source>A comma separated list of relative file or folder paths to exclude from formatting.</source>
-        <target state="new">A comma separated list of relative file or folder paths to exclude from formatting.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting">
+        <source>A list of relative file or folder paths to exclude from formatting.</source>
+        <target state="new">A list of relative file or folder paths to exclude from formatting.</target>
         <note />
       </trans-unit>
-      <trans-unit id="A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
-        <source>A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
-        <target state="new">A comma separated list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
+      <trans-unit id="A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty">
+        <source>A list of relative file or folder paths to include in formatting. All files are formatted if empty.</source>
+        <target state="new">A list of relative file or folder paths to include in formatting. All files are formatted if empty.</target>
         <note />
       </trans-unit>
       <trans-unit id="Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory">

--- a/tests/CodeFormatterTests.cs
+++ b/tests/CodeFormatterTests.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
             var match = new Regex(pattern, RegexOptions.Multiline).Match(log);
 
             Assert.True(match.Success, log);
-            Assert.Equal("Program.cs", match.Groups[1].Value);
+            Assert.EndsWith("Program.cs", match.Groups[1].Value);
         }
 
         [Fact]
@@ -276,7 +276,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
             var match = new Regex(pattern, RegexOptions.Multiline).Match(log);
 
             Assert.True(match.Success, log);
-            Assert.Equal("Program.cs", match.Groups[1].Value);
+            Assert.EndsWith("Program.cs", match.Groups[1].Value);
         }
 
         [Fact]

--- a/tests/ProgramTests.cs
+++ b/tests/ProgramTests.cs
@@ -38,10 +38,10 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         public void FilesFormattedDirectorySeparatorInsensitive()
         {
             var filePath = $"other_items{Path.DirectorySeparatorChar}OtherClass.cs";
-            var files = Program.GetRootedPaths(filePath, folder: null);
+            var files = Program.GetRootedPaths(new[] { filePath }, folder: null);
 
             var filePathAlt = $"other_items{Path.AltDirectorySeparatorChar}OtherClass.cs";
-            var filesAlt = Program.GetRootedPaths(filePathAlt, folder: null);
+            var filesAlt = Program.GetRootedPaths(new[] { filePathAlt }, folder: null);
 
             Assert.True(files.IsSubsetOf(filesAlt));
         }


### PR DESCRIPTION
#### Problem

1. in Windows as well as in Unix-like operating systems, if the file path contains comma, we cannot reliably use `--files` option.
2. we are currently incompatible with shell globbing expansion; without using additional tools as workaround (such as https://github.com/dotnet/format/issues/9#issuecomment-541097833).

#### Solution

Change the semantics of `--include` or `--files` and `--exclude` options from `comma-separated` to `space-separated`.

Now we can do things like `dotnet-format --files {src,test}/**/*.cs` or
`git ls-files :/{src,tests}/*.cs | xargs dotnet-format --files`.

#### Additional change

Change the output message to include full path to file, so we can distinguish the clashing files.

```diff
- dotnet-format --files ./fileA.cs,"a sub directory/fileA.cs"
+ dotnet-format --files ./fileA.cs "a sub directory/fileA.cs"

-  Formatted code file 'fileA.cs'.
-  Formatted code file 'fileA.cs'.
+  Formatted code file '/path/fileA.cs'.
+  Formatted code file '/path/a sub directory/fileA.cs'.
```