### PR TITLE
Update versions of dependencies

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -6,7 +6,6 @@
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
     <add key="roslyn-analyzers" value="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json" />
-    <add key="system-commandline" value="https://dotnet.myget.org/F/system-commandline/api/v3/index.json" />
     <add key="vs-editor" value="https://myget.org/F/vs-editor/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,19 +9,20 @@
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
     <MicrosoftNETCoreCompilersPackageVersion>3.6.0-1.20114.6</MicrosoftNETCoreCompilersPackageVersion>
+    <MicrosoftExtensionsVersion>3.1.1</MicrosoftExtensionsVersion>
   </PropertyGroup>
   <!--
     Other Dependency versions
   -->
   <PropertyGroup>
-    <SystemCommandLineExperimentalVersion>0.1.0-alpha-63729-01</SystemCommandLineExperimentalVersion>
-    <SystemCommandLineRenderingVersion>0.1.0-alpha-63729-01</SystemCommandLineRenderingVersion>
-    <MicrosoftBuildLocatorVersion>1.2.2</MicrosoftBuildLocatorVersion>
-    <MicrosoftCodeAnalysisAnalyzerTestingVersion>1.0.0-beta1-63812-02</MicrosoftCodeAnalysisAnalyzerTestingVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>2.1.1</MicrosoftExtensionsDependencyInjectionVersion>
-    <MicrosoftExtensionsLoggingVersion>2.1.1</MicrosoftExtensionsLoggingVersion>
+    <SystemCommandLineVersion>2.0.0-beta1.20104.2</SystemCommandLineVersion>
+    <SystemCommandLineRenderingVersion>0.3.0-alpha.20104.2</SystemCommandLineRenderingVersion>
+    <MicrosoftBuildLocatorVersion>1.2.6</MicrosoftBuildLocatorVersion>
+    <MicrosoftCodeAnalysisAnalyzerTestingVersion>1.0.1-beta1.20114.4</MicrosoftCodeAnalysisAnalyzerTestingVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>$(MicrosoftExtensionsVersion)</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsLoggingVersion>$(MicrosoftExtensionsVersion)</MicrosoftExtensionsLoggingVersion>
     <MicrosoftVisualStudioCodingConventionsVersion>1.1.20180503.2</MicrosoftVisualStudioCodingConventionsVersion>
-    <MicrosoftCodeAnalysisAnalyzersVersion>3.0.0-beta2.20077.2</MicrosoftCodeAnalysisAnalyzersVersion>
+    <MicrosoftCodeAnalysisAnalyzersVersion>3.0.0-beta2.20114.1</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisVersion>$(MicrosoftNETCoreCompilersPackageVersion)</MicrosoftCodeAnalysisVersion>
     <SystemTextJsonVersion>4.7.0</SystemTextJsonVersion>
   </PropertyGroup>

--- a/src/Logging/NullScope.cs
+++ b/src/Logging/NullScope.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Tools.Logging
+{
+    internal class NullScope : IDisposable
+    {
+        public static NullScope Instance { get; } = new NullScope();
+
+        private NullScope()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Logging/SimpleConsoleLogger.cs
+++ b/src/Logging/SimpleConsoleLogger.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.CommandLine;
 using System.CommandLine.Rendering;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions.Internal;
 
 namespace Microsoft.CodeAnalysis.Tools.Logging
 {
@@ -71,13 +70,13 @@ namespace Microsoft.CodeAnalysis.Tools.Logging
         {
             var messageColor = _logLevelColorMap[logLevel];
             _terminal.ForegroundColor = messageColor;
-            _terminal.Out.WriteLine($"  {message}");
+            _terminal.Out.Write($"  {message}{Environment.NewLine}");
             _terminal.ResetColor();
         }
 
         void LogToConsole(string message)
         {
-            _console.Out.WriteLine($"  {message}");
+            _console.Out.Write($"  {message}{Environment.NewLine}");
         }
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Immutable;
 using System.CommandLine;
-using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.IO;
 using System.Linq;
@@ -24,25 +23,43 @@ namespace Microsoft.CodeAnalysis.Tools
 
         private static async Task<int> Main(string[] args)
         {
-            var parser = new CommandLineBuilder(new Command("dotnet-format", handler: CommandHandler.Create(typeof(Program).GetMethod(nameof(Run)))))
-                .UseParseDirective()
-                .UseHelp()
-                .UseDebugDirective()
-                .UseSuggestDirective()
-                .RegisterWithDotnetSuggest()
-                .UseParseErrorReporting()
-                .UseExceptionHandler()
-                .AddOption(new Option(new[] { "--folder", "-f" }, Resources.The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option, new Argument<string>(() => null)))
-                .AddOption(new Option(new[] { "--workspace", "-w" }, Resources.The_solution_or_project_file_to_operate_on_If_a_file_is_not_specified_the_command_will_search_the_current_directory_for_one, new Argument<string>(() => null)))
-                .AddOption(new Option(new[] { "--include", "--files" }, Resources.A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty, new Argument<string>(() => null)))
-                .AddOption(new Option(new[] { "--exclude" }, Resources.A_comma_separated_list_of_relative_file_or_folder_paths_to_exclude_from_formatting, new Argument<string>(() => null)))
-                .AddOption(new Option(new[] { "--check", "--dry-run" }, Resources.Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted, new Argument<bool>()))
-                .AddOption(new Option(new[] { "--report" }, Resources.Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory, new Argument<string>(() => null)))
-                .AddOption(new Option(new[] { "--verbosity", "-v" }, Resources.Set_the_verbosity_level_Allowed_values_are_quiet_minimal_normal_detailed_and_diagnostic, new Argument<string>() { Arity = ArgumentArity.ExactlyOne }.FromAmong(_verbosityLevels)))
-                .UseVersionOption()
-                .Build();
+            var rootCommand = new RootCommand
+            {
+                new Option(new[] { "--folder", "-f" }, Resources.The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option)
+                {
+                    Argument = new Argument<string>(() => null)
+                },
+                new Option(new[] { "--workspace", "-w" }, Resources.The_solution_or_project_file_to_operate_on_If_a_file_is_not_specified_the_command_will_search_the_current_directory_for_one)
+                {
+                    Argument = new Argument<string>(() => null)
+                },
+                new Option(new[] { "--include", "--files" }, Resources.A_comma_separated_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty)
+                {
+                    Argument = new Argument<string>(() => null)
+                },
+                new Option(new[] { "--exclude" }, Resources.A_comma_separated_list_of_relative_file_or_folder_paths_to_exclude_from_formatting)
+                {
+                    Argument = new Argument<string>(() => null)
+                },
+                new Option(new[] { "--check", "--dry-run" }, Resources.Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted)
+                {
+                    Argument = new Argument<bool>()
+                },
+                new Option(new[] { "--report" }, Resources.Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory)
+                {
+                    Argument = new Argument<string>(() => null)
+                },
+                new Option(new[] { "--verbosity", "-v" }, Resources.Set_the_verbosity_level_Allowed_values_are_quiet_minimal_normal_detailed_and_diagnostic)
+                {
+                    Argument = new Argument<string>() { Arity = ArgumentArity.ExactlyOne }.FromAmong(_verbosityLevels)
+                },
+            };
 
-            return await parser.InvokeAsync(args).ConfigureAwait(false);
+            rootCommand.Description = "dotnet-format";
+            rootCommand.Handler = CommandHandler.Create(typeof(Program).GetMethod(nameof(Run)));
+
+            // Parse the incoming args and invoke the handler
+            return await rootCommand.InvokeAsync(args);
         }
 
         public static async Task<int> Run(string folder, string workspace, string verbosity, bool check, string include, string exclude, string report, IConsole console = null)

--- a/src/dotnet-format.csproj
+++ b/src/dotnet-format.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.CommandLine.Experimental" Version="$(SystemCommandLineExperimentalVersion)" />
+    <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageReference Include="System.CommandLine.Rendering" Version="$(SystemCommandLineRenderingVersion)" />
     <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />

--- a/tests/Formatters/AbstractFormatterTests.cs
+++ b/tests/Formatters/AbstractFormatterTests.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Testing;
@@ -15,6 +16,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Tools.Formatters;
 using Microsoft.CodeAnalysis.Tools.Tests.Utilities;
 using Microsoft.CodeAnalysis.Tools.Utilities;
+using Microsoft.CodeAnalysis.VisualBasic;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.CodingConventions;
 using Microsoft.VisualStudio.Composition;
@@ -24,6 +26,14 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
 {
     public abstract class AbstractFormatterTest
     {
+        private static readonly MetadataReference CorlibReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location).WithAliases(ImmutableArray.Create("global", "corlib"));
+        private static readonly MetadataReference SystemReference = MetadataReference.CreateFromFile(typeof(System.Diagnostics.Debug).Assembly.Location).WithAliases(ImmutableArray.Create("global", "system"));
+        private static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
+        private static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
+
+        private static readonly MetadataReference SystemCollectionsImmutableReference = MetadataReference.CreateFromFile(typeof(ImmutableArray).Assembly.Location);
+        private static readonly MetadataReference MicrosoftVisualBasicReference = MetadataReference.CreateFromFile(typeof(Microsoft.VisualBasic.Strings).Assembly.Location);
+
         private static readonly Lazy<IExportProviderFactory> ExportProviderFactory;
 
         static AbstractFormatterTest()
@@ -235,15 +245,15 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
                 .CurrentSolution
                 .AddProject(ProjectInfo.Create(projectId, VersionStamp.Create(), DefaultTestProjectName, DefaultTestProjectName, language, filePath: DefaultTestProjectPath))
                 .WithProjectCompilationOptions(projectId, compilationOptions)
-                .AddMetadataReference(projectId, MetadataReferences.CorlibReference)
-                .AddMetadataReference(projectId, MetadataReferences.SystemReference)
-                .AddMetadataReference(projectId, MetadataReferences.SystemCoreReference)
-                .AddMetadataReference(projectId, MetadataReferences.CodeAnalysisReference)
-                .AddMetadataReference(projectId, MetadataReferences.SystemCollectionsImmutableReference);
+                .AddMetadataReference(projectId, CorlibReference)
+                .AddMetadataReference(projectId, SystemReference)
+                .AddMetadataReference(projectId, SystemCoreReference)
+                .AddMetadataReference(projectId, CodeAnalysisReference)
+                .AddMetadataReference(projectId, SystemCollectionsImmutableReference);
 
             if (language == LanguageNames.VisualBasic)
             {
-                solution = solution.AddMetadataReference(projectId, MetadataReferences.MicrosoftVisualBasicReference);
+                solution = solution.AddMetadataReference(projectId, MicrosoftVisualBasicReference);
             }
 
             foreach (var transform in OptionsTransforms)

--- a/tests/Utilities/TestLogger.cs
+++ b/tests/Utilities/TestLogger.cs
@@ -2,8 +2,8 @@
 
 using System;
 using System.Text;
+using Microsoft.CodeAnalysis.Tools.Logging;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions.Internal;
 
 namespace Microsoft.CodeAnalysis.Tools.Tests.Utilities
 {


### PR DESCRIPTION
The latest version of System.CommandLine supports loading options via [response files](https://github.com/dotnet/command-line-api/wiki/Features-overview#response-files). This could be our solution to the request to support a configuration file (https://github.com/dotnet/format/issues/520).