### PR TITLE
Support file globbing in --include and --exclude options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All changes to the project will be documented in this file.
 ## [4.0.x] - Not Yet Released
 ### Merged PRs:
 - [Combine --check and --dry-run into a single option. (541)](https://github.com/dotnet/format/pull/541)
+- [Use space-separated paths instead of comma-separated for --include and --exclude (551)](https://github.com/dotnet/format/pull/551)
+- [Support loading commandline options from response files (552)](https://github.com/dotnet/format/pull/552)
+- [Support file globbing in --include and --exclude options (555)](https://github.com/dotnet/format/pull/555)
 
 ## [3.3.111304] - 2020-02-13
 [View Complete Diff of Changes](https://github.com/dotnet/format/compare/3ecea99de4bb82b724bf11134279b5aaf8dd1f2f...7c8f67a570f5fde6a247704733d6742f93c0fa48)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ jobs:
       condition: not(succeeded())
 
 - job: Linux
-  pool: 
+  pool:
     name: NetCorePublic-Pool
     queue: BuildPool.Ubuntu.1604.Amd64.Open
   variables:
@@ -73,9 +73,9 @@ jobs:
         ArtifactName: '$(_os) $(_configuration)'
       continueOnError: true
       condition: not(succeeded())
-      
+
 - job: Windows_Spanish
-  pool: 
+  pool:
    name: NetCorePublic-Pool
    queue: buildpool.windows.10.amd64.es.vs2017.open
   variables:
@@ -103,5 +103,20 @@ jobs:
       inputs:
         PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\$(_configuration)'
         ArtifactName: 'Spanish $(_os) $(_configuration)'
+      continueOnError: true
+      condition: not(succeeded())
+
+- job: Formatting_Check
+  pool:
+    vmImage: 'vs2017-win2016'
+  timeoutInMinutes: 5
+  steps:
+    - script: dotnet run --project ./src/dotnet-format.csproj -- --folder . --exclude ./tests/projects/ --check --report ./artifacts/log/ -v diag
+      displayName: Build and Test
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Logs
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)\artifacts\log\'
+        ArtifactName: 'Formatting Check'
       continueOnError: true
       condition: not(succeeded())

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,7 +112,7 @@ jobs:
   timeoutInMinutes: 5
   steps:
     - script: dotnet run --project ./src/dotnet-format.csproj -- --folder . --exclude ./tests/projects/ --check --report ./artifacts/log/ -v diag
-      displayName: Build and Test
+      displayName: Run dotnet-format
     - task: PublishBuildArtifacts@1
       displayName: Publish Logs
       inputs:

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,20 +15,19 @@ It is required to specify a workspace when running dotnet-format. Choosing a wor
 
 ### Filter files to format
 
-You can further narrow the list of files to be formatted by limiting to set of included files that are not excluded.
+You can further narrow the list of files to be formatted by limiting to set of included files that are not excluded. File globbing is supported.
 
-- `--include` - A comma separated list of relative file or folder paths to include in formatting.
-- `--exclude` - A comma separated list of relative file or folder paths to exclude from formatting.
+- `--include` - A list of relative file or folder paths to include in formatting.
+- `--exclude` - A list of relative file or folder paths to exclude from formatting.
 
 *Example:*
 
-Other repos built as part of your project can be included using git submodules. These submodules likely contain their own .editorconfig files that are set as `root = true`. This
-makes it difficult to validate formatting for your project as formatting mistakes in submodules are treated as errors.
+Other repos built as part of your project can be included using git submodules. These submodules likely contain their own .editorconfig files that are set as `root = true`. This makes it difficult to validate formatting for your project as formatting mistakes in submodules are treated as errors.
 
-The following command sets the repo folder as the workspace. It then includes the `./src` and `./tests` folders for formatting. The `submodule-a` folder is excluded from the formatting validation.
+The following command sets the repo folder as the workspace. It then includes the `src` and `tests` folders for formatting. The `submodule-a` folder is excluded from the formatting validation.
 
 ```console
-dotnet format -f . --include ./src,./tests --exclude ./src/submodule-a --check
+dotnet format -f . --include ./src/ ./tests/ --exclude ./src/submodule-a/ --check
 ```
 
 ### Logging and Reports

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,6 +20,7 @@
     <MicrosoftBuildLocatorVersion>1.2.6</MicrosoftBuildLocatorVersion>
     <MicrosoftCodeAnalysisAnalyzerTestingVersion>1.0.1-beta1.20114.4</MicrosoftCodeAnalysisAnalyzerTestingVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>$(MicrosoftExtensionsVersion)</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsFileSystemGlobbingVersion>$(MicrosoftExtensionsVersion)</MicrosoftExtensionsFileSystemGlobbingVersion>
     <MicrosoftExtensionsLoggingVersion>$(MicrosoftExtensionsVersion)</MicrosoftExtensionsLoggingVersion>
     <MicrosoftVisualStudioCodingConventionsVersion>1.1.20180503.2</MicrosoftVisualStudioCodingConventionsVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>3.0.0-beta2.20114.1</MicrosoftCodeAnalysisAnalyzersVersion>

--- a/perf/FormattedFiles.cs
+++ b/perf/FormattedFiles.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
+using Microsoft.CodeAnalysis.Tools.Utilities;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 
@@ -10,11 +12,12 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
     [SimpleJob(RuntimeMoniker.NetCoreApp21)]
     public class FormattedFiles
     {
-        private const string UnformattedProjectPath = "tests/projects/for_code_formatter/unformatted_project";
-        private const string UnformattedProjectFilePath = UnformattedProjectPath + "/unformatted_project.csproj";
+        private const string UnformattedProjectPath = "tests/projects/for_code_formatter/unformatted_project/";
+        private const string UnformattedProjectFilePath = UnformattedProjectPath + "unformatted_project.csproj";
         private const string UnformattedSolutionFilePath = "tests/projects/for_code_formatter/unformatted_solution/unformatted_solution.sln";
+
         private static readonly EmptyLogger EmptyLogger = new EmptyLogger();
-        private static readonly Matcher FileMatcher = new Matcher();
+        private static readonly Matcher AllFileMatcher = SourceFileMatcher.CreateMatcher(Array.Empty<string>(), Array.Empty<string>());
 
         [IterationSetup]
         public void NoFilesFormattedSetup()
@@ -33,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
                 LogLevel.Error,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                FileMatcher,
+                AllFileMatcher,
                 reportPath: string.Empty);
             _ = CodeFormatter.FormatWorkspaceAsync(options, EmptyLogger, default).GetAwaiter().GetResult();
         }
@@ -48,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
                 LogLevel.Error,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                FileMatcher,
+                AllFileMatcher,
                 reportPath: string.Empty);
             _ = CodeFormatter.FormatWorkspaceAsync(options, EmptyLogger, default).GetAwaiter().GetResult();
         }
@@ -63,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
                 LogLevel.Error,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                FileMatcher,
+                AllFileMatcher,
                 reportPath: string.Empty);
             _ = CodeFormatter.FormatWorkspaceAsync(options, EmptyLogger, default).GetAwaiter().GetResult();
         }

--- a/perf/FormattedFiles.cs
+++ b/perf/FormattedFiles.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Immutable;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
+using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools.Perf
@@ -11,7 +13,8 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
         private const string UnformattedProjectPath = "tests/projects/for_code_formatter/unformatted_project";
         private const string UnformattedProjectFilePath = UnformattedProjectPath + "/unformatted_project.csproj";
         private const string UnformattedSolutionFilePath = "tests/projects/for_code_formatter/unformatted_solution/unformatted_solution.sln";
-        private static EmptyLogger EmptyLogger = new EmptyLogger();
+        private static readonly EmptyLogger EmptyLogger = new EmptyLogger();
+        private static readonly Matcher FileMatcher = new Matcher();
 
         [IterationSetup]
         public void NoFilesFormattedSetup()
@@ -30,8 +33,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
                 LogLevel.Error,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                ImmutableHashSet<string>.Empty,
-                ImmutableHashSet<string>.Empty,
+                FileMatcher,
                 reportPath: string.Empty);
             _ = CodeFormatter.FormatWorkspaceAsync(options, EmptyLogger, default).GetAwaiter().GetResult();
         }
@@ -46,8 +48,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
                 LogLevel.Error,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                ImmutableHashSet<string>.Empty,
-                ImmutableHashSet<string>.Empty,
+                FileMatcher,
                 reportPath: string.Empty);
             _ = CodeFormatter.FormatWorkspaceAsync(options, EmptyLogger, default).GetAwaiter().GetResult();
         }
@@ -62,8 +63,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
                 LogLevel.Error,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                ImmutableHashSet<string>.Empty,
-                ImmutableHashSet<string>.Empty,
+                FileMatcher,
                 reportPath: string.Empty);
             _ = CodeFormatter.FormatWorkspaceAsync(options, EmptyLogger, default).GetAwaiter().GetResult();
         }

--- a/perf/NoFilesFormatted.cs
+++ b/perf/NoFilesFormatted.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
+using Microsoft.CodeAnalysis.Tools.Utilities;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 
@@ -10,12 +12,12 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
     [SimpleJob(RuntimeMoniker.NetCoreApp21)]
     public class NoFilesFormatted
     {
-        private const string FormattedProjectPath = "tests/projects/for_code_formatter/formatted_project";
-        private const string FormattedProjectFilePath = FormattedProjectPath + "/formatted_project.csproj";
+        private const string FormattedProjectPath = "tests/projects/for_code_formatter/formatted_project/";
+        private const string FormattedProjectFilePath = FormattedProjectPath + "formatted_project.csproj";
         private const string FormattedSolutionFilePath = "tests/projects/for_code_formatter/formatted_solution/formatted_solution.sln";
 
         private static readonly EmptyLogger EmptyLogger = new EmptyLogger();
-        private static readonly Matcher FileMatcher = new Matcher();
+        private static readonly Matcher AllFileMatcher = SourceFileMatcher.CreateMatcher(Array.Empty<string>(), Array.Empty<string>());
 
         [IterationSetup]
         public void NoFilesFormattedSetup()
@@ -34,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
                 LogLevel.Error,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                FileMatcher,
+                AllFileMatcher,
                 reportPath: string.Empty);
             _ = CodeFormatter.FormatWorkspaceAsync(options, EmptyLogger, default).GetAwaiter().GetResult();
         }
@@ -49,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
                 LogLevel.Error,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                FileMatcher,
+                AllFileMatcher,
                 reportPath: string.Empty);
             _ = CodeFormatter.FormatWorkspaceAsync(options, EmptyLogger, default).GetAwaiter().GetResult();
         }
@@ -64,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
                 LogLevel.Error,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                FileMatcher,
+                AllFileMatcher,
                 reportPath: string.Empty);
             _ = CodeFormatter.FormatWorkspaceAsync(options, EmptyLogger, default).GetAwaiter().GetResult();
         }

--- a/perf/NoFilesFormatted.cs
+++ b/perf/NoFilesFormatted.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Immutable;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
+using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools.Perf
@@ -12,7 +14,8 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
         private const string FormattedProjectFilePath = FormattedProjectPath + "/formatted_project.csproj";
         private const string FormattedSolutionFilePath = "tests/projects/for_code_formatter/formatted_solution/formatted_solution.sln";
 
-        private static EmptyLogger EmptyLogger = new EmptyLogger();
+        private static readonly EmptyLogger EmptyLogger = new EmptyLogger();
+        private static readonly Matcher FileMatcher = new Matcher();
 
         [IterationSetup]
         public void NoFilesFormattedSetup()
@@ -31,8 +34,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
                 LogLevel.Error,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                ImmutableHashSet<string>.Empty,
-                ImmutableHashSet<string>.Empty,
+                FileMatcher,
                 reportPath: string.Empty);
             _ = CodeFormatter.FormatWorkspaceAsync(options, EmptyLogger, default).GetAwaiter().GetResult();
         }
@@ -47,8 +49,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
                 LogLevel.Error,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                ImmutableHashSet<string>.Empty,
-                ImmutableHashSet<string>.Empty,
+                FileMatcher,
                 reportPath: string.Empty);
             _ = CodeFormatter.FormatWorkspaceAsync(options, EmptyLogger, default).GetAwaiter().GetResult();
         }
@@ -63,8 +64,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
                 LogLevel.Error,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                ImmutableHashSet<string>.Empty,
-                ImmutableHashSet<string>.Empty,
+                FileMatcher,
                 reportPath: string.Empty);
             _ = CodeFormatter.FormatWorkspaceAsync(options, EmptyLogger, default).GetAwaiter().GetResult();
         }

--- a/perf/RealWorldSolution.cs
+++ b/perf/RealWorldSolution.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
+using Microsoft.CodeAnalysis.Tools.Utilities;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 
@@ -13,10 +15,11 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
     [Config(typeof(RealWorldConfig))]
     public class RealWorldSolution
     {
-        private const string UnformattedSolutionFilePath = "temp/project-system/ProjectSystem.sln";
-        private const string UnformattedFolderFilePath = "temp/project-system";
+        private const string UnformattedFolderFilePath = "temp/project-system/";
+        private const string UnformattedSolutionFilePath = UnformattedFolderFilePath + "ProjectSystem.sln";
+
         private static EmptyLogger EmptyLogger = new EmptyLogger();
-        private static readonly Matcher FileMatcher = new Matcher();
+        private static readonly Matcher AllFileMatcher = SourceFileMatcher.CreateMatcher(Array.Empty<string>(), Array.Empty<string>());
 
         [IterationSetup]
         public void RealWorldSolutionIterationSetup()
@@ -35,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
                 LogLevel.Error,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                FileMatcher,
+                AllFileMatcher,
                 reportPath: string.Empty);
             _ = CodeFormatter.FormatWorkspaceAsync(options, EmptyLogger, default).GetAwaiter().GetResult();
         }
@@ -50,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
                 LogLevel.Error,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                FileMatcher,
+                AllFileMatcher,
                 reportPath: string.Empty);
             _ = CodeFormatter.FormatWorkspaceAsync(options, EmptyLogger, default).GetAwaiter().GetResult();
         }

--- a/perf/RealWorldSolution.cs
+++ b/perf/RealWorldSolution.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Immutable;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Environments;
-using BenchmarkDotNet.Horology;
 using BenchmarkDotNet.Jobs;
+using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools.Perf
@@ -15,6 +16,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
         private const string UnformattedSolutionFilePath = "temp/project-system/ProjectSystem.sln";
         private const string UnformattedFolderFilePath = "temp/project-system";
         private static EmptyLogger EmptyLogger = new EmptyLogger();
+        private static readonly Matcher FileMatcher = new Matcher();
 
         [IterationSetup]
         public void RealWorldSolutionIterationSetup()
@@ -33,8 +35,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
                 LogLevel.Error,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                ImmutableHashSet<string>.Empty,
-                ImmutableHashSet<string>.Empty,
+                FileMatcher,
                 reportPath: string.Empty);
             _ = CodeFormatter.FormatWorkspaceAsync(options, EmptyLogger, default).GetAwaiter().GetResult();
         }
@@ -49,8 +50,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
                 LogLevel.Error,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                ImmutableHashSet<string>.Empty,
-                ImmutableHashSet<string>.Empty,
+                FileMatcher,
                 reportPath: string.Empty);
             _ = CodeFormatter.FormatWorkspaceAsync(options, EmptyLogger, default).GetAwaiter().GetResult();
         }

--- a/perf/Utilities/EmptyLogger.cs
+++ b/perf/Utilities/EmptyLogger.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Tools.Logging;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools.Perf
@@ -16,13 +19,6 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
 
         public bool IsEnabled(LogLevel logLevel) => false;
 
-        public IDisposable BeginScope<TState>(TState state) => new EmptyScope();
-
-        private class EmptyScope : IDisposable
-        {
-            public void Dispose()
-            {
-            }
-        }
+        public IDisposable BeginScope<TState>(TState state) => NullScope.Instance;
     }
 }

--- a/perf/Utilities/MSBuildRegister.cs
+++ b/perf/Utilities/MSBuildRegister.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Tools.MSBuild;
 

--- a/perf/Utilities/SolutionPathSetter.cs
+++ b/perf/Utilities/SolutionPathSetter.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System;
 using System.IO;
 using System.Threading;
 

--- a/perf/Utilities/WorkspacePathHelper.cs
+++ b/perf/Utilities/WorkspacePathHelper.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.IO;
 
 namespace Microsoft.CodeAnalysis.Tools.Perf
 {

--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -348,7 +348,7 @@ namespace Microsoft.CodeAnalysis.Tools
             Matcher fileMatcher,
             CancellationToken cancellationToken)
         {
-            if (fileMatcher is object && !fileMatcher.Match(document.FilePath).HasMatches)
+            if (!fileMatcher.Match(document.FilePath).HasMatches)
             {
                 // If a files list was passed in, then ignore files not present in the list.
                 return true;

--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -99,6 +99,12 @@ namespace Microsoft.CodeAnalysis.Tools
                 if (exitCode == 0 && !string.IsNullOrWhiteSpace(reportPath))
                 {
                     var reportFilePath = GetReportFilePath(reportPath);
+                    var reportFolderPath = Path.GetDirectoryName(reportFilePath);
+
+                    if (!Directory.Exists(reportFolderPath))
+                    {
+                        Directory.CreateDirectory(reportFolderPath);
+                    }
 
                     logger.LogInformation(Resources.Writing_formatting_report_to_0, reportFilePath);
                     var seralizerOptions = new JsonSerializerOptions

--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Tools.Formatters;
 using Microsoft.CodeAnalysis.Tools.Utilities;
 using Microsoft.CodeAnalysis.Tools.Workspaces;
+using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.CodingConventions;
 
@@ -34,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Tools
             ILogger logger,
             CancellationToken cancellationToken)
         {
-            var (workspaceFilePath, workspaceType, logLevel, saveFormattedFiles, _, pathsToInclude, pathsToExclude, reportPath) = options;
+            var (workspaceFilePath, workspaceType, logLevel, saveFormattedFiles, _, fileMatcher, reportPath) = options;
             var logWorkspaceWarnings = logLevel == LogLevel.Trace;
 
             logger.LogInformation(string.Format(Resources.Formatting_code_files_in_workspace_0, workspaceFilePath));
@@ -44,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Tools
             var workspaceStopwatch = Stopwatch.StartNew();
 
             using (var workspace = await OpenWorkspaceAsync(
-                workspaceFilePath, workspaceType, pathsToInclude, logWorkspaceWarnings, logger, cancellationToken).ConfigureAwait(false))
+                workspaceFilePath, workspaceType, fileMatcher, logWorkspaceWarnings, logger, cancellationToken).ConfigureAwait(false))
             {
                 if (workspace is null)
                 {
@@ -60,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Tools
                 logger.LogTrace(Resources.Determining_formattable_files);
 
                 var (fileCount, formatableFiles) = await DetermineFormattableFiles(
-                    solution, projectPath, pathsToInclude, pathsToExclude, logger, cancellationToken).ConfigureAwait(false);
+                    solution, projectPath, fileMatcher, logger, cancellationToken).ConfigureAwait(false);
 
                 var determineFilesMS = workspaceStopwatch.ElapsedMilliseconds - loadWorkspaceMS;
                 logger.LogTrace(Resources.Complete_in_0_ms, determineFilesMS);
@@ -137,7 +138,7 @@ namespace Microsoft.CodeAnalysis.Tools
         private static async Task<Workspace> OpenWorkspaceAsync(
             string workspacePath,
             WorkspaceType workspaceType,
-            ImmutableHashSet<string> pathsToInclude,
+            Matcher fileMatcher,
             bool logWorkspaceWarnings,
             ILogger logger,
             CancellationToken cancellationToken)
@@ -145,7 +146,7 @@ namespace Microsoft.CodeAnalysis.Tools
             if (workspaceType == WorkspaceType.Folder)
             {
                 var folderWorkspace = FolderWorkspace.Create();
-                await folderWorkspace.OpenFolder(workspacePath, pathsToInclude, cancellationToken);
+                await folderWorkspace.OpenFolder(workspacePath, fileMatcher, cancellationToken);
                 return folderWorkspace;
             }
 
@@ -241,8 +242,7 @@ namespace Microsoft.CodeAnalysis.Tools
         internal static async Task<(int, ImmutableArray<(DocumentId, OptionSet, ICodingConventionsSnapshot)>)> DetermineFormattableFiles(
             Solution solution,
             string projectPath,
-            ImmutableHashSet<string> pathsToInclude,
-            ImmutableHashSet<string> pathsToExclude,
+            Matcher fileMatcher,
             ILogger logger,
             CancellationToken cancellationToken)
         {
@@ -272,7 +272,7 @@ namespace Microsoft.CodeAnalysis.Tools
 
                 // Get project documents and options with .editorconfig settings applied.
                 var getProjectDocuments = project.DocumentIds.Select(documentId => GetDocumentAndOptions(
-                    project, documentId, pathsToInclude, pathsToExclude, codingConventionsManager, optionsApplier, cancellationToken));
+                    project, documentId, fileMatcher, codingConventionsManager, optionsApplier, cancellationToken));
                 getDocumentsAndOptions.AddRange(getProjectDocuments);
             }
 
@@ -310,15 +310,14 @@ namespace Microsoft.CodeAnalysis.Tools
         private static async Task<(Document, OptionSet, ICodingConventionsSnapshot, bool)> GetDocumentAndOptions(
             Project project,
             DocumentId documentId,
-            ImmutableHashSet<string> pathsToInclude,
-            ImmutableHashSet<string> pathsToExclude,
+            Matcher fileMatcher,
             ICodingConventionsManager codingConventionsManager,
             EditorConfigOptionsApplier optionsApplier,
             CancellationToken cancellationToken)
         {
             var document = project.Solution.GetDocument(documentId);
 
-            if (await ShouldIgnoreDocument(document, pathsToInclude, pathsToExclude, cancellationToken))
+            if (await ShouldIgnoreDocument(document, fileMatcher, cancellationToken))
             {
                 return (null, null, null, false);
             }
@@ -340,11 +339,10 @@ namespace Microsoft.CodeAnalysis.Tools
 
         private static async Task<bool> ShouldIgnoreDocument(
             Document document,
-            ImmutableHashSet<string> pathsToInclude,
-            ImmutableHashSet<string> pathsToExclude,
+            Matcher fileMatcher,
             CancellationToken cancellationToken)
         {
-            if (!pathsToInclude.IsEmpty && !pathsToInclude.Any(path => document.FilePath.StartsWith(path, StringComparison.OrdinalIgnoreCase)))
+            if (fileMatcher is object && !fileMatcher.Match(document.FilePath).HasMatches)
             {
                 // If a files list was passed in, then ignore files not present in the list.
                 return true;
@@ -356,11 +354,6 @@ namespace Microsoft.CodeAnalysis.Tools
             else if (await GeneratedCodeUtilities.IsGeneratedCodeAsync(document, cancellationToken).ConfigureAwait(false))
             {
                 // Ignore generated code files.
-                return true;
-            }
-            else if (!pathsToExclude.IsEmpty && pathsToExclude.Any(path => document.FilePath.StartsWith(path, StringComparison.OrdinalIgnoreCase)))
-            {
-                // Ignore file in, or under a folder in the list to exclude
                 return true;
             }
             else

--- a/src/FormatOptions.cs
+++ b/src/FormatOptions.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
+using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools
@@ -12,8 +12,7 @@ namespace Microsoft.CodeAnalysis.Tools
         public LogLevel LogLevel { get; }
         public bool SaveFormattedFiles { get; }
         public bool ChangesAreErrors { get; }
-        public ImmutableHashSet<string> PathsToInclude { get; }
-        public ImmutableHashSet<string> PathsToExclude { get; }
+        public Matcher FileMatcher { get; }
         public string ReportPath { get; }
 
         public FormatOptions(
@@ -22,8 +21,7 @@ namespace Microsoft.CodeAnalysis.Tools
             LogLevel logLevel,
             bool saveFormattedFiles,
             bool changesAreErrors,
-            ImmutableHashSet<string> pathsToInclude,
-            ImmutableHashSet<string> pathsToExclude,
+            Matcher fileMatcher,
             string reportPath)
         {
             WorkspaceFilePath = workspaceFilePath;
@@ -31,8 +29,7 @@ namespace Microsoft.CodeAnalysis.Tools
             LogLevel = logLevel;
             SaveFormattedFiles = saveFormattedFiles;
             ChangesAreErrors = changesAreErrors;
-            PathsToInclude = pathsToInclude;
-            PathsToExclude = pathsToExclude;
+            FileMatcher = fileMatcher;
             ReportPath = reportPath;
         }
 
@@ -42,8 +39,7 @@ namespace Microsoft.CodeAnalysis.Tools
             out LogLevel logLevel,
             out bool saveFormattedFiles,
             out bool changesAreErrors,
-            out ImmutableHashSet<string> pathsToInclude,
-            out ImmutableHashSet<string> pathsToExclude,
+            out Matcher fileMatcher,
             out string reportPath)
         {
             workspaceFilePath = WorkspaceFilePath;
@@ -51,8 +47,7 @@ namespace Microsoft.CodeAnalysis.Tools
             logLevel = LogLevel;
             saveFormattedFiles = SaveFormattedFiles;
             changesAreErrors = ChangesAreErrors;
-            pathsToInclude = PathsToInclude;
-            pathsToExclude = PathsToExclude;
+            fileMatcher = FileMatcher;
             reportPath = ReportPath;
         }
     }

--- a/src/Logging/NullScope.cs
+++ b/src/Logging/NullScope.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -35,11 +35,11 @@ namespace Microsoft.CodeAnalysis.Tools
                 },
                 new Option(new[] { "--include", "--files" }, Resources.A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty)
                 {
-                    Argument = new Argument<string[]>(() => null)
+                    Argument = new Argument<string[]>(() => Array.Empty<string>())
                 },
                 new Option(new[] { "--exclude" }, Resources.A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting)
                 {
-                    Argument = new Argument<string[]>(() => null)
+                    Argument = new Argument<string[]>(() => Array.Empty<string>())
                 },
                 new Option(new[] { "--check", "--dry-run" }, Resources.Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted)
                 {

--- a/src/Utilities/SourceFileMatcher.cs
+++ b/src/Utilities/SourceFileMatcher.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Utilities/SourceFileMatcher.cs
+++ b/src/Utilities/SourceFileMatcher.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.FileSystemGlobbing;
+
+namespace Microsoft.CodeAnalysis.Tools.Utilities
+{
+    internal static class SourceFileMatcher
+    {
+        private static IEnumerable<string> AllFilesList => new[] { @"**/*.*" };
+
+        public static Matcher CreateMatcher(IEnumerable<string> include, IEnumerable<string> exclude)
+        {
+            var fileMatcher = new Matcher(StringComparison.OrdinalIgnoreCase);
+            fileMatcher.AddIncludePatterns(include.Any() ? include : AllFilesList);
+            fileMatcher.AddExcludePatterns(exclude);
+            return fileMatcher;
+        }
+    }
+}

--- a/src/Workspaces/FolderWorkspace.cs
+++ b/src/Workspaces/FolderWorkspace.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace Microsoft.CodeAnalysis.Tools.Workspaces
 {
@@ -32,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Tools.Workspaces
             return new FolderWorkspace(hostServices);
         }
 
-        public async Task<Solution> OpenFolder(string folderPath, ImmutableHashSet<string> pathsToInclude, CancellationToken cancellationToken)
+        public async Task<Solution> OpenFolder(string folderPath, Matcher fileMatcher, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(folderPath) || !Directory.Exists(folderPath))
             {
@@ -41,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Tools.Workspaces
 
             ClearSolution();
 
-            var solutionInfo = await FolderSolutionLoader.LoadSolutionInfoAsync(folderPath, pathsToInclude, cancellationToken).ConfigureAwait(false);
+            var solutionInfo = await FolderSolutionLoader.LoadSolutionInfoAsync(folderPath, fileMatcher, cancellationToken).ConfigureAwait(false);
 
             OnSolutionAdded(solutionInfo);
 

--- a/src/Workspaces/FolderWorkspace_FolderSolutionLoader.cs
+++ b/src/Workspaces/FolderWorkspace_FolderSolutionLoader.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace Microsoft.CodeAnalysis.Tools.Workspaces
 {
@@ -14,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Tools.Workspaces
             private static ImmutableArray<ProjectLoader> ProjectLoaders
                 => ImmutableArray.Create<ProjectLoader>(new CSharpProjectLoader(), new VisualBasicProjectLoader());
 
-            public static async Task<SolutionInfo> LoadSolutionInfoAsync(string folderPath, ImmutableHashSet<string> pathsToInclude, CancellationToken cancellationToken)
+            public static async Task<SolutionInfo> LoadSolutionInfoAsync(string folderPath, Matcher fileMatcher, CancellationToken cancellationToken)
             {
                 var absoluteFolderPath = Path.IsPathFullyQualified(folderPath)
                     ? folderPath
@@ -25,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Tools.Workspaces
                 // Create projects for each of the supported languages.
                 foreach (var loader in ProjectLoaders)
                 {
-                    var projectInfo = await loader.LoadProjectInfoAsync(folderPath, pathsToInclude, cancellationToken);
+                    var projectInfo = await loader.LoadProjectInfoAsync(folderPath, fileMatcher, cancellationToken);
                     if (projectInfo is null)
                     {
                         continue;

--- a/src/dotnet-format.csproj
+++ b/src/dotnet-format.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="System.CommandLine.Rendering" Version="$(SystemCommandLineRenderingVersion)" />
     <PackageReference Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(MicrosoftExtensionsFileSystemGlobbingVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.CodingConventions" Version="$(MicrosoftVisualStudioCodingConventionsVersion)" Publish="true" />
 

--- a/tests/Formatters/AbstractFormatterTests.cs
+++ b/tests/Formatters/AbstractFormatterTests.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Testing;
@@ -16,7 +15,7 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Tools.Formatters;
 using Microsoft.CodeAnalysis.Tools.Tests.Utilities;
 using Microsoft.CodeAnalysis.Tools.Utilities;
-using Microsoft.CodeAnalysis.VisualBasic;
+using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.CodingConventions;
 using Microsoft.VisualStudio.Composition;
@@ -95,14 +94,15 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
             var solution = GetSolution(TestState.Sources.ToArray(), TestState.AdditionalFiles.ToArray(), TestState.AdditionalReferences.ToArray());
             var project = solution.Projects.Single();
             var document = project.Documents.Single();
+            var fileMatcher = new Matcher();
+            fileMatcher.AddInclude(document.FilePath);
             var formatOptions = new FormatOptions(
                 workspaceFilePath: project.FilePath,
                 workspaceType: WorkspaceType.Folder,
                 logLevel: LogLevel.Trace,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                pathsToInclude: ImmutableHashSet.Create(document.FilePath),
-                pathsToExclude: ImmutableHashSet.Create<string>(),
+                fileMatcher,
                 reportPath: string.Empty);
 
             var pathsToFormat = await GetOnlyFileToFormatAsync(solution, editorConfig);

--- a/tests/Formatters/AbstractFormatterTests.cs
+++ b/tests/Formatters/AbstractFormatterTests.cs
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Tools.Formatters;
 using Microsoft.CodeAnalysis.Tools.Tests.Utilities;
 using Microsoft.CodeAnalysis.Tools.Utilities;
-using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.CodingConventions;
 using Microsoft.VisualStudio.Composition;
@@ -94,8 +93,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
             var solution = GetSolution(TestState.Sources.ToArray(), TestState.AdditionalFiles.ToArray(), TestState.AdditionalReferences.ToArray());
             var project = solution.Projects.Single();
             var document = project.Documents.Single();
-            var fileMatcher = new Matcher();
-            fileMatcher.AddInclude(document.FilePath);
+            var fileMatcher = SourceFileMatcher.CreateMatcher(new[] { document.FilePath }, exclude: Array.Empty<string>());
             var formatOptions = new FormatOptions(
                 workspaceFilePath: project.FilePath,
                 workspaceType: WorkspaceType.Folder,

--- a/tests/Formatters/FormattedFilesTests.cs
+++ b/tests/Formatters/FormattedFilesTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Tools.Formatters;
 using Microsoft.CodeAnalysis.Tools.Tests.Utilities;
+using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -49,14 +50,15 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
             var solution = GetSolution(TestState.Sources.ToArray(), TestState.AdditionalFiles.ToArray(), TestState.AdditionalReferences.ToArray());
             var project = solution.Projects.Single();
             var document = project.Documents.Single();
+            var fileMatcher = new Matcher();
+            fileMatcher.AddInclude(document.FilePath);
             var formatOptions = new FormatOptions(
                 workspaceFilePath: project.FilePath,
                 workspaceType: WorkspaceType.Folder,
                 logLevel: LogLevel.Trace,
                 saveFormattedFiles: false,
                 changesAreErrors: false,
-                pathsToInclude: ImmutableHashSet.Create(document.FilePath),
-                pathsToExclude: ImmutableHashSet.Create<string>(),
+                fileMatcher,
                 reportPath: string.Empty);
 
             var pathsToFormat = await GetOnlyFileToFormatAsync(solution, editorConfig);

--- a/tests/Formatters/FormattedFilesTests.cs
+++ b/tests/Formatters/FormattedFilesTests.cs
@@ -1,12 +1,12 @@
-﻿using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Tools.Formatters;
 using Microsoft.CodeAnalysis.Tools.Tests.Utilities;
-using Microsoft.Extensions.FileSystemGlobbing;
+using Microsoft.CodeAnalysis.Tools.Utilities;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
@@ -50,8 +50,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Formatters
             var solution = GetSolution(TestState.Sources.ToArray(), TestState.AdditionalFiles.ToArray(), TestState.AdditionalReferences.ToArray());
             var project = solution.Projects.Single();
             var document = project.Documents.Single();
-            var fileMatcher = new Matcher();
-            fileMatcher.AddInclude(document.FilePath);
+            var fileMatcher = SourceFileMatcher.CreateMatcher(new[] { document.FilePath }, exclude: Array.Empty<string>());
             var formatOptions = new FormatOptions(
                 workspaceFilePath: project.FilePath,
                 workspaceType: WorkspaceType.Folder,

--- a/tests/ProgramTests.cs
+++ b/tests/ProgramTests.cs
@@ -33,17 +33,5 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
 
             Assert.Equal(formatResult.ExitCode, exitCode);
         }
-
-        [Fact]
-        public void FilesFormattedDirectorySeparatorInsensitive()
-        {
-            var filePath = $"other_items{Path.DirectorySeparatorChar}OtherClass.cs";
-            var files = Program.GetRootedPaths(new[] { filePath }, folder: null);
-
-            var filePathAlt = $"other_items{Path.AltDirectorySeparatorChar}OtherClass.cs";
-            var filesAlt = Program.GetRootedPaths(new[] { filePathAlt }, folder: null);
-
-            Assert.True(files.IsSubsetOf(filesAlt));
-        }
     }
 }


### PR DESCRIPTION
Use the Microsoft.Extensions.FileSystemGlobbing package to handle matching against the included and excluded paths.