### PR TITLE
Use response file for CI formatting check

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,7 +111,7 @@ jobs:
     vmImage: 'vs2017-win2016'
   timeoutInMinutes: 5
   steps:
-    - script: dotnet run --project ./src/dotnet-format.csproj -- --folder . --exclude ./tests/projects/ --check --report ./artifacts/log/ -v diag
+    - script: dotnet run --project ./src/dotnet-format.csproj -- @validate.rsp
       displayName: Run dotnet-format
     - task: PublishBuildArtifacts@1
       displayName: Publish Logs

--- a/validate.rsp
+++ b/validate.rsp
@@ -1,0 +1,9 @@
+--folder
+.
+--exclude
+./tests/projects/
+--check
+--report
+./artifacts/log/
+-v
+diag


### PR DESCRIPTION
Example of using RSP files as configuration files. As requested in https://github.com/dotnet/format/issues/520.