### PR TITLE
fix #581 - Add final newline false positive

### DIFF
--- a/src/Formatters/FinalNewlineFormatter.cs
+++ b/src/Formatters/FinalNewlineFormatter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
 {
     internal sealed class FinalNewlineFormatter : DocumentFormatter
     {
-        protected override string FormatWarningDescription => Resources.Add_final_newline;
+        protected override string FormatWarningDescription => Resources.Fix_final_newline;
 
         protected override async Task<SourceText> FormatFileAsync(
             Document document,

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -192,8 +192,8 @@
   <data name="Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings" xml:space="preserve">
     <value>Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</value>
   </data>
-  <data name="Add_final_newline" xml:space="preserve">
-    <value>Add final newline.</value>
+  <data name="Fix_final_newline" xml:space="preserve">
+    <value>Fix final newline.</value>
   </data>
   <data name="Fix_end_of_line_marker" xml:space="preserve">
     <value>Fix end of line marker.</value>

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -17,11 +17,6 @@
         <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Add_final_newline">
-        <source>Add final newline.</source>
-        <target state="new">Add final newline.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">{0} obsahuje jak soubor projektu MSBuild, tak soubor řešení. Určete, který soubor chcete použít, pomocí parametru --workspace.</target>
@@ -65,6 +60,11 @@
       <trans-unit id="Fix_file_encoding">
         <source>Fix file encoding.</source>
         <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_final_newline">
+        <source>Fix final newline.</source>
+        <target state="new">Fix final newline.</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -17,11 +17,6 @@
         <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Add_final_newline">
-        <source>Add final newline.</source>
-        <target state="new">Add final newline.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">In "{0}" wurden eine MSBuild-Projektdatei und eine Projektmappe gefunden. Geben Sie mit der Option "--workspace" an, welche verwendet werden soll.</target>
@@ -65,6 +60,11 @@
       <trans-unit id="Fix_file_encoding">
         <source>Fix file encoding.</source>
         <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_final_newline">
+        <source>Fix final newline.</source>
+        <target state="new">Fix final newline.</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -17,11 +17,6 @@
         <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Add_final_newline">
-        <source>Add final newline.</source>
-        <target state="new">Add final newline.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">Se encontró un archivo de proyecto y un archivo de solución MSBuild en "{0}". Especifique cuál debe usarse con la opción --workspace.</target>
@@ -65,6 +60,11 @@
       <trans-unit id="Fix_file_encoding">
         <source>Fix file encoding.</source>
         <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_final_newline">
+        <source>Fix final newline.</source>
+        <target state="new">Fix final newline.</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -17,11 +17,6 @@
         <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Add_final_newline">
-        <source>Add final newline.</source>
-        <target state="new">Add final newline.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">Un fichier projet et un fichier solution MSBuild ont été trouvés dans '{0}'. Spécifiez celui à utiliser avec l'option --workspace.</target>
@@ -65,6 +60,11 @@
       <trans-unit id="Fix_file_encoding">
         <source>Fix file encoding.</source>
         <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_final_newline">
+        <source>Fix final newline.</source>
+        <target state="new">Fix final newline.</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -17,11 +17,6 @@
         <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Add_final_newline">
-        <source>Add final newline.</source>
-        <target state="new">Add final newline.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">In '{0}' sono stati trovati sia un file di progetto che un file di soluzione MSBuild. Per specificare quello desiderato, usare l'opzione --workspace.</target>
@@ -65,6 +60,11 @@
       <trans-unit id="Fix_file_encoding">
         <source>Fix file encoding.</source>
         <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_final_newline">
+        <source>Fix final newline.</source>
+        <target state="new">Fix final newline.</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -17,11 +17,6 @@
         <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Add_final_newline">
-        <source>Add final newline.</source>
-        <target state="new">Add final newline.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">MSBuild プロジェクト ファイルとソリューション ファイルが '{0}' で見つかりました。使用するファイルを --workspace オプションで指定してください。</target>
@@ -65,6 +60,11 @@
       <trans-unit id="Fix_file_encoding">
         <source>Fix file encoding.</source>
         <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_final_newline">
+        <source>Fix final newline.</source>
+        <target state="new">Fix final newline.</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -17,11 +17,6 @@
         <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Add_final_newline">
-        <source>Add final newline.</source>
-        <target state="new">Add final newline.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">'{0}'에 MSBuild 프로젝트 파일 및 솔루션 파일이 모두 있습니다. --workspace 옵션에 사용할 파일을 지정하세요.</target>
@@ -65,6 +60,11 @@
       <trans-unit id="Fix_file_encoding">
         <source>Fix file encoding.</source>
         <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_final_newline">
+        <source>Fix final newline.</source>
+        <target state="new">Fix final newline.</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -17,11 +17,6 @@
         <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Add_final_newline">
-        <source>Add final newline.</source>
-        <target state="new">Add final newline.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">W elemencie „{0}” znaleziono zarówno plik rozwiązania, jak i plik projektu MSBuild. Określ plik do użycia za pomocą opcji --workspace.</target>
@@ -65,6 +60,11 @@
       <trans-unit id="Fix_file_encoding">
         <source>Fix file encoding.</source>
         <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_final_newline">
+        <source>Fix final newline.</source>
+        <target state="new">Fix final newline.</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -17,11 +17,6 @@
         <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Add_final_newline">
-        <source>Add final newline.</source>
-        <target state="new">Add final newline.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">Foram encontrados um arquivo de solução e um arquivo de projeto MSBuild em '{0}'. Especifique qual usar com a opção --espaço de trabalho.</target>
@@ -65,6 +60,11 @@
       <trans-unit id="Fix_file_encoding">
         <source>Fix file encoding.</source>
         <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_final_newline">
+        <source>Fix final newline.</source>
+        <target state="new">Fix final newline.</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -17,11 +17,6 @@
         <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Add_final_newline">
-        <source>Add final newline.</source>
-        <target state="new">Add final newline.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">В "{0}" обнаружены как файл проекта, так и файл решения MSBuild. Укажите используемый файл с помощью параметра --workspace.</target>
@@ -65,6 +60,11 @@
       <trans-unit id="Fix_file_encoding">
         <source>Fix file encoding.</source>
         <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_final_newline">
+        <source>Fix final newline.</source>
+        <target state="new">Fix final newline.</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -17,11 +17,6 @@
         <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Add_final_newline">
-        <source>Add final newline.</source>
-        <target state="new">Add final newline.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">Hem bir MSBuild proje dosyası ve çözüm dosyası '{0}' içinde bulundu. Hangi--çalışma alanı seçeneği ile kullanmak için belirtin.</target>
@@ -65,6 +60,11 @@
       <trans-unit id="Fix_file_encoding">
         <source>Fix file encoding.</source>
         <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_final_newline">
+        <source>Fix final newline.</source>
+        <target state="new">Fix final newline.</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -17,11 +17,6 @@
         <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Add_final_newline">
-        <source>Add final newline.</source>
-        <target state="new">Add final newline.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">在“{0}”中同时找到 MSBuild 项目文件和解决方案文件。请指定要将哪一个文件用于 --workspace 选项。</target>
@@ -65,6 +60,11 @@
       <trans-unit id="Fix_file_encoding">
         <source>Fix file encoding.</source>
         <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_final_newline">
+        <source>Fix final newline.</source>
+        <target state="new">Fix final newline.</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -17,11 +17,6 @@
         <target state="new">Accepts a file path, which if provided, will produce a json report in the given directory.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Add_final_newline">
-        <source>Add final newline.</source>
-        <target state="new">Add final newline.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_option">
         <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the --workspace option.</source>
         <target state="translated">在 '{0}' 中同時找到 MSBuild 專案檔和解決方案檔。請指定要搭配 --workspace 選項使用的檔案。</target>
@@ -65,6 +60,11 @@
       <trans-unit id="Fix_file_encoding">
         <source>Fix file encoding.</source>
         <target state="new">Fix file encoding.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Fix_final_newline">
+        <source>Fix final newline.</source>
+        <target state="new">Fix final newline.</target>
         <note />
       </trans-unit>
       <trans-unit id="Fix_whitespace_formatting">


### PR DESCRIPTION
Both `insert_final_newline = false` and `insert_final_newline = true` uses `FinalNewlineFormatter.cs`, so `FormatWarningDescription` was changed to accommodate both cases and be in line with other format warnings(for eg: `Fix_end_of_line_marker`)