### PR TITLE
Command line argument for solution/project as positional argument

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Tools
             return rootCommand;
         }
 
-        public static async Task<int> Run(string? folder, string? workspace, string? verbosity, bool check, string[] include, string[] exclude, string? report, bool includeGenerated, IConsole console = null!)
+        public static async Task<int> Run(string? project, string? folder, string? workspace, string? verbosity, bool check, string[] include, string[] exclude, string? report, bool includeGenerated, IConsole console = null!)
         {
             // Setup logging.
             var serviceCollection = new ServiceCollection();
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.Tools
                 string workspaceDirectory;
                 string workspacePath;
                 WorkspaceType workspaceType;
-
+                workspace ??= project;
                 if (!string.IsNullOrEmpty(folder) && !string.IsNullOrEmpty(workspace))
                 {
                     logger.LogWarning(Resources.Cannot_specify_both_folder_and_workspace_options);

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -157,12 +157,7 @@ namespace Microsoft.CodeAnalysis.Tools
                 }
 
                 workspace ??= project;
-                if (!string.IsNullOrEmpty(folder) && !string.IsNullOrEmpty(workspace))
-                {
-                    logger.LogWarning(Resources.Cannot_specify_both_folder_and_workspace_options);
-                    return 1;
-                }
-                else if (!string.IsNullOrEmpty(workspace))
+                if (!string.IsNullOrEmpty(workspace))
                 {
                     var (isSolution, workspaceFilePath) = MSBuildWorkspaceFinder.FindWorkspace(currentDirectory, workspace);
 
@@ -176,7 +171,10 @@ namespace Microsoft.CodeAnalysis.Tools
                     // a global.json if present.
                     var directoryName = Path.GetDirectoryName(workspacePath);
                     if (directoryName is null)
+                    {
                         throw new Exception($"Unable to find folder at '{workspacePath}'");
+                    }
+
                     workspaceDirectory = directoryName;
                 }
                 else

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -35,6 +37,11 @@ namespace Microsoft.CodeAnalysis.Tools
         {
             var rootCommand = new RootCommand
             {
+                new Argument<string>("project")
+                {
+                    Arity = ArgumentArity.ZeroOrOne,
+                    Description = Resources.The_solution_or_project_file_to_operate_on_If_a_file_is_not_specified_the_command_will_search_the_current_directory_for_one
+                },
                 new Option(new[] { "--folder", "-f" }, Resources.The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option)
                 {
                     Argument = new Argument<string?>(() => null)

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -88,11 +88,17 @@ namespace Microsoft.CodeAnalysis.Tools
 
         private static string? ValidateProjectArgumentAndWorkspace(CommandResult symbolResult)
         {
-            var project = symbolResult.GetArgumentValueOrDefault<string>("project");
-            var workspace = symbolResult.OptionResult("workspace").GetValueOrDefault<string>();
-            if (!string.IsNullOrEmpty(project) && !string.IsNullOrEmpty(workspace))
+            try
             {
-                return Resources.Cannot_specify_both_project_argument_and_workspace_option;
+                var project = symbolResult.GetArgumentValueOrDefault<string>("project");
+                var workspace = symbolResult.ValueForOption<string>("workspace");
+                if (!string.IsNullOrEmpty(project) && !string.IsNullOrEmpty(workspace))
+                {
+                    return Resources.Cannot_specify_both_project_argument_and_workspace_option;
+                }
+            }
+            catch (InvalidOperationException) // Parsing of arguments failed. This will be reported later.
+            {
             }
 
             return null;
@@ -100,13 +106,19 @@ namespace Microsoft.CodeAnalysis.Tools
 
         private static string? ValidateWorkspaceAndFolder(CommandResult symbolResult)
         {
-            var project = symbolResult.GetArgumentValueOrDefault<string>("project");
-            var workspace = symbolResult.OptionResult("workspace").GetValueOrDefault<string>();
-            var folder = symbolResult.OptionResult("folder").GetValueOrDefault<string>();
-            project ??= workspace;
-            if (!string.IsNullOrEmpty(project) && !string.IsNullOrEmpty(folder))
+            try
             {
-                return Resources.Cannot_specify_both_folder_and_workspace_options;
+                var project = symbolResult.GetArgumentValueOrDefault<string>("project");
+                var workspace = symbolResult.ValueForOption<string>("workspace");
+                var folder = symbolResult.ValueForOption<string>("folder");
+                project ??= workspace;
+                if (!string.IsNullOrEmpty(project) && !string.IsNullOrEmpty(folder))
+                {
+                    return Resources.Cannot_specify_both_folder_and_workspace_options;
+                }
+            }
+            catch (InvalidOperationException)// Parsing of arguments failed. This will be reported later.
+            {
             }
 
             return null;

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -25,6 +25,14 @@ namespace Microsoft.CodeAnalysis.Tools
 
         private static async Task<int> Main(string[] args)
         {
+            var rootCommand = CreateCommandLineOptions();
+
+            // Parse the incoming args and invoke the handler
+            return await rootCommand.InvokeAsync(args);
+        }
+
+        public static RootCommand CreateCommandLineOptions()
+        {
             var rootCommand = new RootCommand
             {
                 new Option(new[] { "--folder", "-f" }, Resources.The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option)
@@ -64,9 +72,7 @@ namespace Microsoft.CodeAnalysis.Tools
 
             rootCommand.Description = "dotnet-format";
             rootCommand.Handler = CommandHandler.Create(typeof(Program).GetMethod(nameof(Run)));
-
-            // Parse the incoming args and invoke the handler
-            return await rootCommand.InvokeAsync(args);
+            return rootCommand;
         }
 
         public static async Task<int> Run(string? folder, string? workspace, string? verbosity, bool check, string[] include, string[] exclude, string? report, bool includeGenerated, IConsole console = null!)

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Tools
             return await rootCommand.InvokeAsync(args);
         }
 
-        public static RootCommand CreateCommandLineOptions()
+        internal static RootCommand CreateCommandLineOptions()
         {
             var rootCommand = new RootCommand
             {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -84,44 +84,44 @@ namespace Microsoft.CodeAnalysis.Tools
             rootCommand.AddValidator(ValidateWorkspaceAndFolder);
             rootCommand.Handler = CommandHandler.Create(typeof(Program).GetMethod(nameof(Run)));
             return rootCommand;
-        }
 
-        private static string? ValidateProjectArgumentAndWorkspace(CommandResult symbolResult)
-        {
-            try
+            static string? ValidateProjectArgumentAndWorkspace(CommandResult symbolResult)
             {
-                var project = symbolResult.GetArgumentValueOrDefault<string>("project");
-                var workspace = symbolResult.ValueForOption<string>("workspace");
-                if (!string.IsNullOrEmpty(project) && !string.IsNullOrEmpty(workspace))
+                try
                 {
-                    return Resources.Cannot_specify_both_project_argument_and_workspace_option;
+                    var project = symbolResult.GetArgumentValueOrDefault<string>("project");
+                    var workspace = symbolResult.ValueForOption<string>("workspace");
+                    if (!string.IsNullOrEmpty(project) && !string.IsNullOrEmpty(workspace))
+                    {
+                        return Resources.Cannot_specify_both_project_argument_and_workspace_option;
+                    }
                 }
-            }
-            catch (InvalidOperationException) // Parsing of arguments failed. This will be reported later.
-            {
-            }
-
-            return null;
-        }
-
-        private static string? ValidateWorkspaceAndFolder(CommandResult symbolResult)
-        {
-            try
-            {
-                var project = symbolResult.GetArgumentValueOrDefault<string>("project");
-                var workspace = symbolResult.ValueForOption<string>("workspace");
-                var folder = symbolResult.ValueForOption<string>("folder");
-                project ??= workspace;
-                if (!string.IsNullOrEmpty(project) && !string.IsNullOrEmpty(folder))
+                catch (InvalidOperationException) // Parsing of arguments failed. This will be reported later.
                 {
-                    return Resources.Cannot_specify_both_folder_and_workspace_options;
                 }
-            }
-            catch (InvalidOperationException)// Parsing of arguments failed. This will be reported later.
-            {
+
+                return null;
             }
 
-            return null;
+            static string? ValidateWorkspaceAndFolder(CommandResult symbolResult)
+            {
+                try
+                {
+                    var project = symbolResult.GetArgumentValueOrDefault<string>("project");
+                    var workspace = symbolResult.ValueForOption<string>("workspace");
+                    var folder = symbolResult.ValueForOption<string>("folder");
+                    project ??= workspace;
+                    if (!string.IsNullOrEmpty(project) && !string.IsNullOrEmpty(folder))
+                    {
+                        return Resources.Cannot_specify_both_folder_and_workspace_options;
+                    }
+                }
+                catch (InvalidOperationException)// Parsing of arguments failed. This will be reported later.
+                {
+                }
+
+                return null;
+            }
         }
 
         public static async Task<int> Run(string? project, string? folder, string? workspace, string? verbosity, bool check, string[] include, string[] exclude, string? report, bool includeGenerated, IConsole console = null!)

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -233,5 +233,11 @@
   </data>
   <data name="The_dotnet_CLI_version_is_0" xml:space="preserve">
     <value>The dotnet CLI version is '{0}'.</value>
+  </data>
+  <data name="Cannot_specify_both_project_argument_and_workspace_option" xml:space="preserve">
+    <value>Cannot specify both project argument and workspace option.</value>
+  </data>
+  <data name="Workspace_option_is_deprecated_Use_the_project_argument_instead" xml:space="preserve">
+    <value>"workspace" option is deprecated. Use the project argument instead.</value>
   </data>
 </root>

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
+        <source>Cannot specify both project argument and workspace option.</source>
+        <target state="new">Cannot specify both project argument and workspace option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -197,6 +197,11 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>"workspace" option is deprecated. Use the project argument instead.</source>
+        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">
         <source>Writing formatting report to: '{0}'.</source>
         <target state="new">Writing formatting report to: '{0}'.</target>

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
+        <source>Cannot specify both project argument and workspace option.</source>
+        <target state="new">Cannot specify both project argument and workspace option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -197,6 +197,11 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>"workspace" option is deprecated. Use the project argument instead.</source>
+        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">
         <source>Writing formatting report to: '{0}'.</source>
         <target state="new">Writing formatting report to: '{0}'.</target>

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
+        <source>Cannot specify both project argument and workspace option.</source>
+        <target state="new">Cannot specify both project argument and workspace option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -197,6 +197,11 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>"workspace" option is deprecated. Use the project argument instead.</source>
+        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">
         <source>Writing formatting report to: '{0}'.</source>
         <target state="new">Writing formatting report to: '{0}'.</target>

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
+        <source>Cannot specify both project argument and workspace option.</source>
+        <target state="new">Cannot specify both project argument and workspace option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -197,6 +197,11 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>"workspace" option is deprecated. Use the project argument instead.</source>
+        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">
         <source>Writing formatting report to: '{0}'.</source>
         <target state="new">Writing formatting report to: '{0}'.</target>

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
+        <source>Cannot specify both project argument and workspace option.</source>
+        <target state="new">Cannot specify both project argument and workspace option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -197,6 +197,11 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>"workspace" option is deprecated. Use the project argument instead.</source>
+        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">
         <source>Writing formatting report to: '{0}'.</source>
         <target state="new">Writing formatting report to: '{0}'.</target>

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
+        <source>Cannot specify both project argument and workspace option.</source>
+        <target state="new">Cannot specify both project argument and workspace option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -197,6 +197,11 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>"workspace" option is deprecated. Use the project argument instead.</source>
+        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">
         <source>Writing formatting report to: '{0}'.</source>
         <target state="new">Writing formatting report to: '{0}'.</target>

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
+        <source>Cannot specify both project argument and workspace option.</source>
+        <target state="new">Cannot specify both project argument and workspace option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -197,6 +197,11 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>"workspace" option is deprecated. Use the project argument instead.</source>
+        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">
         <source>Writing formatting report to: '{0}'.</source>
         <target state="new">Writing formatting report to: '{0}'.</target>

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
+        <source>Cannot specify both project argument and workspace option.</source>
+        <target state="new">Cannot specify both project argument and workspace option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -197,6 +197,11 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>"workspace" option is deprecated. Use the project argument instead.</source>
+        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">
         <source>Writing formatting report to: '{0}'.</source>
         <target state="new">Writing formatting report to: '{0}'.</target>

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
+        <source>Cannot specify both project argument and workspace option.</source>
+        <target state="new">Cannot specify both project argument and workspace option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -197,6 +197,11 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>"workspace" option is deprecated. Use the project argument instead.</source>
+        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">
         <source>Writing formatting report to: '{0}'.</source>
         <target state="new">Writing formatting report to: '{0}'.</target>

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
+        <source>Cannot specify both project argument and workspace option.</source>
+        <target state="new">Cannot specify both project argument and workspace option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -197,6 +197,11 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>"workspace" option is deprecated. Use the project argument instead.</source>
+        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">
         <source>Writing formatting report to: '{0}'.</source>
         <target state="new">Writing formatting report to: '{0}'.</target>

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
+        <source>Cannot specify both project argument and workspace option.</source>
+        <target state="new">Cannot specify both project argument and workspace option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -197,6 +197,11 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>"workspace" option is deprecated. Use the project argument instead.</source>
+        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">
         <source>Writing formatting report to: '{0}'.</source>
         <target state="new">Writing formatting report to: '{0}'.</target>

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
+        <source>Cannot specify both project argument and workspace option.</source>
+        <target state="new">Cannot specify both project argument and workspace option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -197,6 +197,11 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>"workspace" option is deprecated. Use the project argument instead.</source>
+        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">
         <source>Writing formatting report to: '{0}'.</source>
         <target state="new">Writing formatting report to: '{0}'.</target>

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
+        <source>Cannot specify both project argument and workspace option.</source>
+        <target state="new">Cannot specify both project argument and workspace option.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Complete_in_0_ms">
         <source>Complete in {0}ms.</source>
         <target state="new">Complete in {0}ms.</target>

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -197,6 +197,11 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>"workspace" option is deprecated. Use the project argument instead.</source>
+        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">
         <source>Writing formatting report to: '{0}'.</source>
         <target state="new">Writing formatting report to: '{0}'.</target>

--- a/tests/ProgramTests.cs
+++ b/tests/ProgramTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
-using System.IO;
+using System.Collections.Generic;
+using System.CommandLine;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Tools.Tests
@@ -32,6 +33,37 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
             var exitCode = Program.GetExitCode(formatResult, check: false);
 
             Assert.Equal(formatResult.ExitCode, exitCode);
+        }
+
+        [Fact]
+        public void CommandLine_OptionsAreParedCorrectly()
+        {
+            // Arrange
+            var sut = Program.CreateCommandLineOptions();
+
+            // Act
+            var result = sut.Parse(new[] {
+                "--folder", "folder",
+                "--workspace", "workspace",
+                "--include", "include1", "include2",
+                "--exclude", "exclude1", "exclude2",
+                "--check",
+                "--report", "report",
+                "--verbosity", "verbosity",
+                "--include-generated"});
+
+            // Assert
+            Assert.Equal(0, result.Errors.Count);
+            Assert.Equal(0, result.UnmatchedTokens.Count);
+            Assert.Equal(0, result.UnparsedTokens.Count);
+            Assert.Equal("folder", result.ValueForOption("folder"));
+            Assert.Equal("workspace", result.ValueForOption("workspace"));
+            Assert.Collection(result.ValueForOption<IEnumerable<string>>("include"), i0 => Assert.Equal("include1", i0), i1 => Assert.Equal("include2", i1));
+            Assert.Collection(result.ValueForOption<IEnumerable<string>>("exclude"), i0 => Assert.Equal("exclude1", i0), i1 => Assert.Equal("exclude2", i1));
+            Assert.True(result.ValueForOption<bool>("check"));
+            Assert.Equal("report", result.ValueForOption("report"));
+            Assert.Equal("verbosity", result.ValueForOption("verbosity"));
+            Assert.True(result.ValueForOption<bool>("include-generated"));
         }
     }
 }

--- a/tests/ProgramTests.cs
+++ b/tests/ProgramTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
     public class ProgramTests
     {
         // Should be kept in sync with Program.Run
-        private delegate void TestCommandHandlerDelegate(string project, string folder, string workspace, string verbosity, bool check, 
+        private delegate void TestCommandHandlerDelegate(string project, string folder, string workspace, string verbosity, bool check,
             string[] include, string[] exclude, string report, bool includeGenerated);
 
         [Fact]
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
             var handlerWasCalled = false;
             sut.Handler = CommandHandler.Create(new TestCommandHandlerDelegate(TestCommandHandler));
 
-            void TestCommandHandler(string project, string folder, string workspace, string verbosity, bool check, 
+            void TestCommandHandler(string project, string folder, string workspace, string verbosity, bool check,
                 string[] include, string[] exclude, string report, bool includeGenerated)
             {
                 handlerWasCalled = true;

--- a/tests/ProgramTests.cs
+++ b/tests/ProgramTests.cs
@@ -137,5 +137,19 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
             // Assert
             Assert.True(handlerWasCalled);
         }
+
+
+        [Fact]
+        public void CommandLine_ProjectArgument_FailesIfSpecifiedTwice()
+        {
+            // Arrange
+            var sut = Program.CreateCommandLineOptions();
+
+            // Act
+            var result = sut.Parse(new[] { "projectValue1", "projectValue2" });
+
+            // Assert
+            Assert.Equal(1, result.Errors.Count);
+        }
     }
 }

--- a/tests/ProgramTests.cs
+++ b/tests/ProgramTests.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.Parsing;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.Tools.Tests
@@ -36,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         }
 
         [Fact]
-        public void CommandLine_OptionsAreParedCorrectly()
+        public void CommandLine_OptionsAreParsedCorrectly()
         {
             // Arrange
             var sut = Program.CreateCommandLineOptions();
@@ -64,6 +65,50 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
             Assert.Equal("report", result.ValueForOption("report"));
             Assert.Equal("verbosity", result.ValueForOption("verbosity"));
             Assert.True(result.ValueForOption<bool>("include-generated"));
+        }
+
+        [Fact]
+        public void CommandLine_ProjectArgument_Simple()
+        {
+            // Arrange
+            var sut = Program.CreateCommandLineOptions();
+
+            // Act
+            var result = sut.Parse(new[] { "projectValue" });
+
+            // Assert
+            Assert.Equal(0, result.Errors.Count);
+            Assert.Equal("projectValue", result.CommandResult.GetArgumentValueOrDefault("project"));
+        }
+
+        [Fact]
+        public void CommandLine_ProjectArgument_WithOption_AfterArgument()
+        {
+            // Arrange
+            var sut = Program.CreateCommandLineOptions();
+
+            // Act
+            var result = sut.Parse(new[] { "projectValue", "--verbosity", "verbosity" });
+
+            // Assert
+            Assert.Equal(0, result.Errors.Count);
+            Assert.Equal("projectValue", result.CommandResult.GetArgumentValueOrDefault("project"));
+            Assert.Equal("verbosity", result.ValueForOption("verbosity"));
+        }
+
+        [Fact]
+        public void CommandLine_ProjectArgument_WithOption_BeforeArgument()
+        {
+            // Arrange
+            var sut = Program.CreateCommandLineOptions();
+
+            // Act
+            var result = sut.Parse(new[] { "--verbosity", "verbosity", "projectValue" });
+
+            // Assert
+            Assert.Equal(0, result.Errors.Count);
+            Assert.Equal("projectValue", result.CommandResult.GetArgumentValueOrDefault("project"));
+            Assert.Equal("verbosity", result.ValueForOption("verbosity"));
         }
     }
 }

--- a/tests/ProgramTests.cs
+++ b/tests/ProgramTests.cs
@@ -123,14 +123,14 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
             var sut = Program.CreateCommandLineOptions();
             var handlerWasCalled = false;
             sut.Handler = CommandHandler.Create(new TestCommandHandlerDelegate(TestCommandHandler));
-            
+
             void TestCommandHandler(string project, string folder, string workspace, string verbosity, bool check, string[] include, string[] exclude, string report, bool includeGenerated)
             {
                 handlerWasCalled = true;
                 Assert.Equal("projectValue", project);
                 Assert.Equal("verbosity", verbosity);
             };
-            
+
             // Act
             var result = sut.Invoke(new[] { "--verbosity", "verbosity", "projectValue" });
 

--- a/tests/ProgramTests.cs
+++ b/tests/ProgramTests.cs
@@ -11,7 +11,6 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
     public class ProgramTests
     {
         // Should be kept in sync with Program.Run
-        // 
         private delegate void TestCommandHandlerDelegate(string project, string folder, string workspace, string verbosity, bool check, string[] include, string[] exclude, string report, bool includeGenerated);
 
         [Fact]
@@ -64,8 +63,12 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
             Assert.Equal(0, result.UnparsedTokens.Count);
             Assert.Equal("folder", result.ValueForOption("folder"));
             Assert.Equal("workspace", result.ValueForOption("workspace"));
-            Assert.Collection(result.ValueForOption<IEnumerable<string>>("include"), i0 => Assert.Equal("include1", i0), i1 => Assert.Equal("include2", i1));
-            Assert.Collection(result.ValueForOption<IEnumerable<string>>("exclude"), i0 => Assert.Equal("exclude1", i0), i1 => Assert.Equal("exclude2", i1));
+            Assert.Collection(result.ValueForOption<IEnumerable<string>>("include"),
+                i0 => Assert.Equal("include1", i0),
+                i1 => Assert.Equal("include2", i1));
+            Assert.Collection(result.ValueForOption<IEnumerable<string>>("exclude"),
+                i0 => Assert.Equal("exclude1", i0),
+                i1 => Assert.Equal("exclude2", i1));
             Assert.True(result.ValueForOption<bool>("check"));
             Assert.Equal("report", result.ValueForOption("report"));
             Assert.Equal("verbosity", result.ValueForOption("verbosity"));
@@ -159,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
             var sut = Program.CreateCommandLineOptions();
 
             // Act
-            var result = sut.Parse(new[] { "projectValue", "--workspace", "workspace"});
+            var result = sut.Parse(new[] { "projectValue", "--workspace", "workspace" });
 
             // Assert
             Assert.Equal(1, result.Errors.Count);
@@ -186,6 +189,19 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
 
             // Act
             var result = sut.Parse(new[] { "--workspace", "workspace", "--folder", "folder" });
+
+            // Assert
+            Assert.Equal(1, result.Errors.Count);
+        }
+
+        [Fact]
+        public void CommandLine_InvalidArgumentsDontCrashTheValidators()
+        {
+            // Arrange
+            var sut = Program.CreateCommandLineOptions();
+
+            // Act
+            var result = sut.Parse(new[] { "--workspace", "workspace1", "--workspace", "workspace2" });
 
             // Assert
             Assert.Equal(1, result.Errors.Count);

--- a/tests/ProgramTests.cs
+++ b/tests/ProgramTests.cs
@@ -11,7 +11,8 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
     public class ProgramTests
     {
         // Should be kept in sync with Program.Run
-        private delegate void TestCommandHandlerDelegate(string project, string folder, string workspace, string verbosity, bool check, string[] include, string[] exclude, string report, bool includeGenerated);
+        private delegate void TestCommandHandlerDelegate(string project, string folder, string workspace, string verbosity, bool check, 
+            string[] include, string[] exclude, string report, bool includeGenerated);
 
         [Fact]
         public void ExitCodeIsOneWithCheckAndAnyFilesFormatted()
@@ -127,7 +128,8 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
             var handlerWasCalled = false;
             sut.Handler = CommandHandler.Create(new TestCommandHandlerDelegate(TestCommandHandler));
 
-            void TestCommandHandler(string project, string folder, string workspace, string verbosity, bool check, string[] include, string[] exclude, string report, bool includeGenerated)
+            void TestCommandHandler(string project, string folder, string workspace, string verbosity, bool check, 
+                string[] include, string[] exclude, string report, bool includeGenerated)
             {
                 handlerWasCalled = true;
                 Assert.Equal("projectValue", project);
@@ -140,7 +142,6 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
             // Assert
             Assert.True(handlerWasCalled);
         }
-
 
         [Fact]
         public void CommandLine_ProjectArgument_FailesIfSpecifiedTwice()

--- a/tests/ProgramTests.cs
+++ b/tests/ProgramTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
                 "--include-generated"});
 
             // Assert
-            Assert.Equal(0, result.Errors.Count);
+            Assert.Equal(1, result.Errors.Count); // folder and workspace can not be combined
             Assert.Equal(0, result.UnmatchedTokens.Count);
             Assert.Equal(0, result.UnparsedTokens.Count);
             Assert.Equal("folder", result.ValueForOption("folder"));
@@ -147,6 +147,45 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
 
             // Act
             var result = sut.Parse(new[] { "projectValue1", "projectValue2" });
+
+            // Assert
+            Assert.Equal(1, result.Errors.Count);
+        }
+
+        [Fact]
+        public void CommandLine_ProjectArgumentAndWorkspaceCanNotBeCombined()
+        {
+            // Arrange
+            var sut = Program.CreateCommandLineOptions();
+
+            // Act
+            var result = sut.Parse(new[] { "projectValue", "--workspace", "workspace"});
+
+            // Assert
+            Assert.Equal(1, result.Errors.Count);
+        }
+
+        [Fact]
+        public void CommandLine_ProjectWorkspaceAndFolderCanNotBeCombined1()
+        {
+            // Arrange
+            var sut = Program.CreateCommandLineOptions();
+
+            // Act
+            var result = sut.Parse(new[] { "projectValue", "--folder", "folder" });
+
+            // Assert
+            Assert.Equal(1, result.Errors.Count);
+        }
+
+        [Fact]
+        public void CommandLine_ProjectWorkspaceAndFolderCanNotBeCombined2()
+        {
+            // Arrange
+            var sut = Program.CreateCommandLineOptions();
+
+            // Act
+            var result = sut.Parse(new[] { "--workspace", "workspace", "--folder", "folder" });
 
             // Assert
             Assert.Equal(1, result.Errors.Count);


### PR DESCRIPTION
Fixes #489

```
dotnet-format:
  dotnet-format

Usage:
  dotnet-format [options] [<project>]

Arguments:
  <project>    Die Projektmappe oder Projektdatei, die verwendet werden soll. Wenn keine Datei angegeben ist,
               durchsucht der Befehl das aktuelle Verzeichnis nach einer Datei.

Options:
  -f, --folder <folder>           The folder to operate on. Cannot be used with the `--workspace` option.
  -w, --workspace <workspace>     Die Projektmappe oder Projektdatei, die verwendet werden soll. Wenn keine Datei
                                  angegeben ist, durchsucht der Befehl das aktuelle Verzeichnis nach einer Datei.
  --files, --include <include>    A list of relative file or folder paths to include in formatting. All files are
                                  formatted if empty.
  --exclude <exclude>             A list of relative file or folder paths to exclude from formatting.
  --check, --dry-run              Formats files without saving changes to disk. Terminates with a non-zero exit code
                                  if any files were formatted.
  --report <report>               Accepts a file path, which if provided, will produce a json report in the given
                                  directory.
  -v, --verbosity <verbosity>     Legen Sie den Ausführlichkeitsgrad fest. Zulässige Werte sind "q[uiet]",
                                  "m[inimal]", "n[ormal]", "d[etailed]" und "diag[nostic]".
  --version                       Show version information
  -?, -h, --help                  Show help and usage information
```