### PR TITLE
Fix typo in DocumentFormatter

### DIFF
--- a/src/Formatters/DocumentFormatter.cs
+++ b/src/Formatters/DocumentFormatter.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
             var changes = formattedText.GetChangeRanges(originalText);
             if (workspaceFolder is null)
             {
-                throw new Exception($"Unable to fine directory name for '{workspacePath}'");
+                throw new Exception($"Unable to find directory name for '{workspacePath}'");
             }
 
             foreach (var change in changes)


### PR DESCRIPTION
Typo in the exception message. 'fine' should be 'find' - guess from the context.