### PR TITLE
Add using directive formatting

### DIFF
--- a/docs/Supported-.editorconfig-options.md
+++ b/docs/Supported-.editorconfig-options.md
@@ -60,3 +60,9 @@ These formatting rules concern the use of single lines versus separate lines for
 
 - csharp_preserve_single_line_statements (default value: `true`)
 - csharp_preserve_single_line_blocks (default value: `true`)
+
+**Organize using directives**
+These formatting rules concern the sorting and display of using directives and Imports statements.
+
+- dotnet_sort_system_directives_first  (default value: `true`)
+- dotnet_separate_import_directive_groups  (default value: `true`)

--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -29,6 +29,7 @@ namespace Microsoft.CodeAnalysis.Tools
             new FinalNewlineFormatter(),
             new EndOfLineFormatter(),
             new CharsetFormatter(),
+            new ImportsFormatter(),
         }.ToImmutableArray();
 
         public static async Task<WorkspaceFormatResult> FormatWorkspaceAsync(

--- a/src/Formatters/ImportsFormatter.cs
+++ b/src/Formatters/ImportsFormatter.cs
@@ -1,0 +1,34 @@
+﻿
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.CodingConventions;
+
+namespace Microsoft.CodeAnalysis.Tools.Formatters
+{
+    /// <summary>
+    /// ImportsFormatter that uses the <see cref="Formatter"/> to format document import directives.
+    /// </summary>
+    internal sealed class ImportsFormatter : DocumentFormatter
+    {
+        // TODO: Use warning from Resources.
+        protected override string FormatWarningDescription => "Fix imports.";
+
+        protected override async Task<SourceText> FormatFileAsync(
+            Document document,
+            SourceText sourceText,
+            OptionSet options,
+            ICodingConventionsSnapshot codingConventions,
+            FormatOptions formatOptions,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            var formattedDocument = await Formatter.OrganizeImportsAsync(document, cancellationToken).ConfigureAwait(false);
+            return await formattedDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}
+


### PR DESCRIPTION
I was playing around with dotnet-format and just for fun added support for following .editorconfig flags:

dotnet_sort_system_directives_first
dotnet_separate_import_directive_groups

It works for me. Please let me know what do you think about it. There is one TODO about using warning from Resources.
