### PR TITLE
Added option checks to warn about deprecations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "dotnet-format -f . --dry-run",
+      "name": "dotnet-format -f --check",
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build",
@@ -13,10 +13,9 @@
       "program": "${workspaceFolder}/artifacts/bin/dotnet-format/Debug/netcoreapp2.1/dotnet-format.dll",
       "args": [
         "-f",
-        ".",
         "-v",
         "diag",
-        "--dry-run"
+        "--check",
       ],
       "cwd": "${workspaceFolder}/src",
       // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
@@ -24,18 +23,17 @@
       "stopAtEntry": false
     },
     {
-      "name": "dotnet-format -w format.sln --dry-run",
+      "name": "dotnet-format format.sln --check",
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
       "program": "${workspaceFolder}/artifacts/bin/dotnet-format/Debug/netcoreapp2.1/dotnet-format.dll",
       "args": [
-        "-w",
         "format.sln",
         "-v",
         "diag",
-        "--dry-run"
+        "--check"
       ],
       "cwd": "${workspaceFolder}",
       // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/README.md
+++ b/README.md
@@ -44,16 +44,15 @@ By default `dotnet-format` will look in the current directory for a project or s
 
 ```sh
 Usage:
-  dotnet-format [options]
+  dotnet-format <project> [options]
 
 Options:
-  -f, --folder <FOLDER>           The folder to operate on. Cannot be used with the `--workspace` option.
-  -w, --workspace <WORKSPACE>     The solution or project file to operate on. If a file is not specified, the command will search the current directory for one.
-  --files, --include <INCLUDE>    A list of relative file or folder paths to include in formatting. All files are formatted if empty.
+  --folder, -f                    Whether to treat the `<project>` path as a folder of files.
+  --include <INCLUDE>             A list of relative file or folder paths to include in formatting. All files are formatted if empty.
   --exclude <EXCLUDE>             A list of relative file or folder paths to exclude from formatting.
-  --check, --dry-run <CHECK>      Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.
+  --check <CHECK>                 Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.
   --report <REPORT>               Accepts a file path, which if provided, will produce a json report in the given directory.
-  -v, --verbosity <VERBOSITY>     Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]
+  --verbosity, -v <VERBOSITY>     Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]
   --version                       Display version information
 ```
 
@@ -62,8 +61,8 @@ Add `format` after `dotnet` and before the command arguments that you want to ru
 | Examples                                                   | Description                                                                                   |
 | ---------------------------------------------------------- |---------------------------------------------------------------------------------------------- |
 | dotnet **format**                                          | Formats the project or solution in the current directory.                                     |
-| dotnet **format** -f &lt;folder&gt;                        | Formats a particular folder and subfolders.                                                   |
-| dotnet **format** -w &lt;workspace&gt;                     | Formats a specific project or solution.                                                       |
+| dotnet **format** &lt;workspace&gt;                        | Formats a specific project or solution.                                                       |
+| dotnet **format** &lt;folder&gt; -f                        | Formats a particular folder and subfolders.                                                   |
 | dotnet **format** -v diag                                  | Formats with very verbose logging.                                                            |
 | dotnet **format** --include Programs.cs Utility\Logging.cs | Formats the files Program.cs and Utility\Logging.cs                                           |
 | dotnet **format** --check                                  | Formats but does not save. Returns a non-zero exit code if any files would have been changed. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,10 +8,10 @@
 
 ### Specify a workspace (Required)
 
-It is required to specify a workspace when running dotnet-format. Choosing a workspace determines which code files are considered for formatting.
+A project path is needed when running dotnet-format. By default, the current folder will be used as the project path. The project path and type of project determines which code files are considered for formatting.
 
-- `--folder` - The folder to operate on. Cannot be used with the `--workspace` option.
-- `--workspace` - The solution or project file to operate on. If a file is not specified, the command will search the current directory for one.
+- Solutions and Projects - By default dotnet-format will open the project path as a MSBuild solution or project.
+- `--folder` - When the folder options is specified the project path will be treated as a folder of code files.
 
 ### Filter files to format
 
@@ -27,7 +27,7 @@ Other repos built as part of your project can be included using git submodules. 
 The following command sets the repo folder as the workspace. It then includes the `src` and `tests` folders for formatting. The `submodule-a` folder is excluded from the formatting validation.
 
 ```console
-dotnet format -f . --include ./src/ ./tests/ --exclude ./src/submodule-a/ --check
+dotnet format -f --include ./src/ ./tests/ --exclude ./src/submodule-a/ --check
 ```
 
 ### Logging and Reports

--- a/src/FormatCommand.cs
+++ b/src/FormatCommand.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System;
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.Tools
+{
+    internal static class FormatCommand
+    {
+        internal static RootCommand CreateCommandLineOptions()
+        {
+            var rootCommand = new RootCommand
+            {
+                new Argument<string>("project")
+                {
+                    Arity = ArgumentArity.ZeroOrOne,
+                    Description = Resources.The_solution_or_project_file_to_operate_on_If_a_file_is_not_specified_the_command_will_search_the_current_directory_for_one
+                },
+                new Option(new[] { "--folder", "-f" }, Resources.Whether_to_treat_the_project_path_as_a_folder_of_files)
+                {
+                    Argument = new Argument<string?>(() => null) { Arity = ArgumentArity.ZeroOrOne },
+                },
+                new Option(new[] { "--workspace", "-w" }, Resources.The_solution_or_project_file_to_operate_on_If_a_file_is_not_specified_the_command_will_search_the_current_directory_for_one)
+                {
+                    Argument = new Argument<string?>(() => null),
+                    IsHidden = true
+                },
+                new Option(new[] { "--include", "--files" }, Resources.A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty)
+                {
+                    Argument = new Argument<string[]>(() => Array.Empty<string>())
+                },
+                new Option(new[] { "--exclude" }, Resources.A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting)
+                {
+                    Argument = new Argument<string[]>(() => Array.Empty<string>())
+                },
+                new Option(new[] { "--check", "--dry-run" }, Resources.Formats_files_without_saving_changes_to_disk_Terminates_with_a_non_zero_exit_code_if_any_files_were_formatted)
+                {
+                    Argument = new Argument<bool>()
+                },
+                new Option(new[] { "--report" }, Resources.Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory)
+                {
+                    Argument = new Argument<string?>(() => null)
+                },
+                new Option(new[] { "--verbosity", "-v" }, Resources.Set_the_verbosity_level_Allowed_values_are_quiet_minimal_normal_detailed_and_diagnostic)
+                {
+                    Argument = new Argument<string?>() { Arity = ArgumentArity.ExactlyOne }
+                },
+                new Option(new[] { "--include-generated" }, Resources.Include_generated_code_files_in_formatting_operations)
+                {
+                    Argument = new Argument<bool>(),
+                    IsHidden = true
+                },
+            };
+
+            rootCommand.Description = "dotnet-format";
+            rootCommand.AddValidator(ValidateProjectArgumentAndWorkspace);
+            rootCommand.AddValidator(ValidateProjectArgumentAndFolder);
+            rootCommand.AddValidator(ValidateWorkspaceAndFolder);
+
+            return rootCommand;
+        }
+
+        private static string? ValidateProjectArgumentAndWorkspace(CommandResult symbolResult)
+        {
+            try
+            {
+                var project = symbolResult.GetArgumentValueOrDefault<string>("project");
+                var workspace = symbolResult.ValueForOption<string>("workspace");
+
+                if (!string.IsNullOrEmpty(project) && !string.IsNullOrEmpty(workspace))
+                {
+                    return Resources.Cannot_specify_both_project_argument_and_workspace_option;
+                }
+            }
+            catch (InvalidOperationException) // Parsing of arguments failed. This will be reported later.
+            {
+            }
+
+            return null;
+        }
+
+        private static string? ValidateProjectArgumentAndFolder(CommandResult symbolResult)
+        {
+            try
+            {
+                var project = symbolResult.GetArgumentValueOrDefault<string>("project");
+                var folder = symbolResult.ValueForOption<string>("folder");
+
+                if (!string.IsNullOrEmpty(project) && !string.IsNullOrEmpty(folder))
+                {
+                    return Resources.Cannot_specify_both_project_argument_and_folder_options;
+                }
+            }
+            catch (InvalidOperationException) // Parsing of arguments failed. This will be reported later.
+            {
+            }
+
+            return null;
+        }
+
+        private static string? ValidateWorkspaceAndFolder(CommandResult symbolResult)
+        {
+            try
+            {
+                var workspace = symbolResult.ValueForOption<string>("workspace");
+                var folder = symbolResult.ValueForOption<string>("folder");
+
+
+                if (!string.IsNullOrEmpty(workspace) && !string.IsNullOrEmpty(folder))
+                {
+                    return Resources.Cannot_specify_both_folder_and_workspace_options;
+                }
+            }
+            catch (InvalidOperationException) // Parsing of arguments failed. This will be reported later.
+            {
+            }
+
+            return null;
+        }
+
+        internal static bool WasOptionUsed(this ParseResult result, params string[] aliases)
+        {
+            return result.Tokens
+                .Where(token => token.Type == TokenType.Option)
+                .Any(token => aliases.Contains(token.Value));
+        }
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
@@ -27,112 +26,29 @@ namespace Microsoft.CodeAnalysis.Tools
         internal const int UnableToLocateMSBuildExitCode = 3;
         internal const int UnableToLocateDotNetCliExitCode = 4;
 
+        private static ParseResult? s_parseResult;
+
         private static async Task<int> Main(string[] args)
         {
-            var rootCommand = CreateCommandLineOptions();
-
-            // Parse the incoming args and invoke the handler
-            return await rootCommand.InvokeAsync(args);
-        }
-
-        internal static RootCommand CreateCommandLineOptions()
-        {
-            var rootCommand = new RootCommand
-            {
-                new Argument<string>("project")
-                {
-                    Arity = ArgumentArity.ZeroOrOne,
-                    Description = Resources.The_solution_or_project_file_to_operate_on_If_a_file_is_not_specified_the_command_will_search_the_current_directory_for_one
-                },
-                new Option(new[] { "--folder", "-f" }, Resources.The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option)
-                {
-                    Argument = new Argument<string?>(() => null)
-                },
-                new Option(new[] { "--workspace", "-w" }, Resources.The_solution_or_project_file_to_operate_on_If_a_file_is_not_specified_the_command_will_search_the_current_directory_for_one)
-                {
-                    Argument = new Argument<string?>(() => null)
-                },
-                new Option(new[] { "--include", "--files" }, Resources.A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty)
-                {
-                    Argument = new Argument<string[]>(() => Array.Empty<string>())
-                },
-                new Option(new[] { "--exclude" }, Resources.A_list_of_relative_file_or_folder_paths_to_exclude_from_formatting)
-                {
-                    Argument = new Argument<string[]>(() => Array.Empty<string>())
-                },
-                new Option(new[] { "--check", "--dry-run" }, Resources.Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted)
-                {
-                    Argument = new Argument<bool>()
-                },
-                new Option(new[] { "--report" }, Resources.Accepts_a_file_path_which_if_provided_will_produce_a_format_report_json_file_in_the_given_directory)
-                {
-                    Argument = new Argument<string?>(() => null)
-                },
-                new Option(new[] { "--verbosity", "-v" }, Resources.Set_the_verbosity_level_Allowed_values_are_quiet_minimal_normal_detailed_and_diagnostic)
-                {
-                    Argument = new Argument<string?>() { Arity = ArgumentArity.ExactlyOne }
-                },
-                new Option(new[] { "--include-generated" }, Resources.Include_generated_code_files_in_formatting_operations)
-                {
-                    Argument = new Argument<bool>(),
-                    IsHidden = true
-                },
-            };
-
-            rootCommand.Description = "dotnet-format";
-            rootCommand.AddValidator(ValidateProjectArgumentAndWorkspace);
-            rootCommand.AddValidator(ValidateWorkspaceAndFolder);
+            var rootCommand = FormatCommand.CreateCommandLineOptions();
             rootCommand.Handler = CommandHandler.Create(typeof(Program).GetMethod(nameof(Run)));
-            return rootCommand;
 
-            static string? ValidateProjectArgumentAndWorkspace(CommandResult symbolResult)
-            {
-                try
-                {
-                    var project = symbolResult.GetArgumentValueOrDefault<string>("project");
-                    var workspace = symbolResult.ValueForOption<string>("workspace");
-                    if (!string.IsNullOrEmpty(project) && !string.IsNullOrEmpty(workspace))
-                    {
-                        return Resources.Cannot_specify_both_project_argument_and_workspace_option;
-                    }
-                }
-                catch (InvalidOperationException) // Parsing of arguments failed. This will be reported later.
-                {
-                }
+            // Parse the incoming args so we can give warnings when deprecated options are used.
+            s_parseResult = rootCommand.Parse(args);
 
-                return null;
-            }
-
-            static string? ValidateWorkspaceAndFolder(CommandResult symbolResult)
-            {
-                try
-                {
-                    var project = symbolResult.GetArgumentValueOrDefault<string>("project");
-                    var workspace = symbolResult.ValueForOption<string>("workspace");
-                    var folder = symbolResult.ValueForOption<string>("folder");
-                    project ??= workspace;
-                    if (!string.IsNullOrEmpty(project) && !string.IsNullOrEmpty(folder))
-                    {
-                        return Resources.Cannot_specify_both_folder_and_workspace_options;
-                    }
-                }
-                catch (InvalidOperationException)// Parsing of arguments failed. This will be reported later.
-                {
-                }
-
-                return null;
-            }
+            return await rootCommand.InvokeAsync(args);
         }
 
         public static async Task<int> Run(string? project, string? folder, string? workspace, string? verbosity, bool check, string[] include, string[] exclude, string? report, bool includeGenerated, IConsole console = null!)
         {
-            // Setup logging.
-            var serviceCollection = new ServiceCollection();
-            var logLevel = GetLogLevel(verbosity);
-            ConfigureServices(serviceCollection, console, logLevel);
+            if (s_parseResult == null)
+            {
+                return 1;
+            }
 
-            var serviceProvider = serviceCollection.BuildServiceProvider();
-            var logger = serviceProvider.GetService<ILogger<Program>>();
+            // Setup logging.
+            var logLevel = GetLogLevel(verbosity);
+            var logger = SetupLogging(console, logLevel);
 
             // Hook so we can cancel and exit when ctrl+c is pressed.
             var cancellationTokenSource = new CancellationTokenSource();
@@ -148,18 +64,44 @@ namespace Microsoft.CodeAnalysis.Tools
             {
                 currentDirectory = Environment.CurrentDirectory;
 
+                // Check for deprecated options and assign package if specified via `-w | -f` options.
+                if (!string.IsNullOrEmpty(workspace) && string.IsNullOrEmpty(project))
+                {
+                    logger.LogWarning(Resources.The_workspace_option_is_deprecated_Use_the_project_argument_instead);
+                    project = workspace;
+                }
+                else if (!string.IsNullOrEmpty(folder) && string.IsNullOrEmpty(project))
+                {
+                    logger.LogWarning(Resources.The_folder_option_is_deprecated_for_specifying_the_path_Pass_the_folder_option_but_specify_the_path_with_the_project_argument_instead);
+                    project = folder;
+                }
+
+                if (s_parseResult.WasOptionUsed("--files"))
+                {
+                    logger.LogWarning(Resources.The_files_option_is_deprecated_Use_the_include_option_instead);
+                }
+
+                if (s_parseResult.WasOptionUsed("--dry-run"))
+                {
+                    logger.LogWarning(Resources.The_dry_run_option_is_deprecated_Use_the_check_option_instead);
+                }
+
                 string workspaceDirectory;
                 string workspacePath;
                 WorkspaceType workspaceType;
-                if (!string.IsNullOrEmpty(workspace) && string.IsNullOrEmpty(project))
-                {
-                    logger.LogWarning(Resources.Workspace_option_is_deprecated_Use_the_project_argument_instead);
-                }
 
-                workspace ??= project;
-                if (!string.IsNullOrEmpty(workspace))
+                // The presence of the folder token means we should treat the project path as a folder path.
+                // This will change in the following version so that the folder option is a bool flag.
+                if (s_parseResult.WasOptionUsed("-f", "--folder"))
                 {
-                    var (isSolution, workspaceFilePath) = MSBuildWorkspaceFinder.FindWorkspace(currentDirectory, workspace);
+                    // If folder isn't populated, then use the current directory
+                    workspacePath = Path.GetFullPath(project ?? ".", Environment.CurrentDirectory);
+                    workspaceDirectory = workspacePath;
+                    workspaceType = WorkspaceType.Folder;
+                }
+                else
+                {
+                    var (isSolution, workspaceFilePath) = MSBuildWorkspaceFinder.FindWorkspace(currentDirectory, project);
 
                     workspacePath = workspaceFilePath;
                     workspaceType = isSolution
@@ -169,23 +111,14 @@ namespace Microsoft.CodeAnalysis.Tools
                     // To ensure we get the version of MSBuild packaged with the dotnet SDK used by the
                     // workspace, use its directory as our working directory which will take into account
                     // a global.json if present.
-                    var directoryName = Path.GetDirectoryName(workspacePath);
-                    if (directoryName is null)
+                    workspaceDirectory = Path.GetDirectoryName(workspacePath);
+                    if (workspaceDirectory is null)
                     {
                         throw new Exception($"Unable to find folder at '{workspacePath}'");
                     }
-
-                    workspaceDirectory = directoryName;
-                }
-                else
-                {
-                    // If folder isn't populated, then use the current directory
-                    folder = Path.GetFullPath(folder ?? ".", Environment.CurrentDirectory);
-                    workspacePath = folder;
-                    workspaceDirectory = workspacePath;
-                    workspaceType = WorkspaceType.Folder;
                 }
 
+                // Load MSBuild
                 Environment.CurrentDirectory = workspaceDirectory;
 
                 if (!TryGetDotNetCliVersion(out var dotnetVersion))
@@ -276,10 +209,16 @@ namespace Microsoft.CodeAnalysis.Tools
             }
         }
 
-        private static void ConfigureServices(ServiceCollection serviceCollection, IConsole console, LogLevel logLevel)
+        private static ILogger<Program> SetupLogging(IConsole console, LogLevel logLevel)
         {
+            var serviceCollection = new ServiceCollection();
             serviceCollection.AddSingleton(new LoggerFactory().AddSimpleConsole(console, logLevel));
             serviceCollection.AddLogging();
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+            var logger = serviceProvider.GetService<ILogger<Program>>();
+
+            return logger;
         }
 
         private static bool TryGetDotNetCliVersion([NotNullWhen(returnValue: true)] out string? dotnetVersion)

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -39,7 +39,17 @@ namespace Microsoft.CodeAnalysis.Tools
             return await rootCommand.InvokeAsync(args);
         }
 
-        public static async Task<int> Run(string? project, string? folder, string? workspace, string? verbosity, bool check, string[] include, string[] exclude, string? report, bool includeGenerated, IConsole console = null!)
+        public static async Task<int> Run(
+            string? project,
+            string? folder,
+            string? workspace,
+            string? verbosity,
+            bool check,
+            string[] include,
+            string[] exclude,
+            string? report,
+            bool includeGenerated,
+            IConsole console = null!)
         {
             if (s_parseResult == null)
             {

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -171,7 +171,7 @@
   <data name="Format_files_but_do_not_save_changes_to_disk" xml:space="preserve">
     <value>Format files, but do not save changes to disk.</value>
   </data>
-  <data name="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted" xml:space="preserve">
+  <data name="Formats_files_without_saving_changes_to_disk_Terminates_with_a_non_zero_exit_code_if_any_files_were_formatted" xml:space="preserve">
     <value>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</value>
   </data>
   <data name="A_list_of_relative_file_or_folder_paths_to_include_in_formatting_All_files_are_formatted_if_empty" xml:space="preserve">
@@ -204,8 +204,8 @@
   <data name="Fix_file_encoding" xml:space="preserve">
     <value>Fix file encoding.</value>
   </data>
-  <data name="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option" xml:space="preserve">
-    <value>The folder to operate on. Cannot be used with the `--workspace` option.</value>
+  <data name="Whether_to_treat_the_project_path_as_a_folder_of_files" xml:space="preserve">
+    <value>Whether to treat the `&lt;project&gt;` path as a folder of files.</value>
   </data>
   <data name="Cannot_specify_both_folder_and_workspace_options" xml:space="preserve">
     <value>Cannot specify both folder and workspace options.</value>
@@ -237,7 +237,19 @@
   <data name="Cannot_specify_both_project_argument_and_workspace_option" xml:space="preserve">
     <value>Cannot specify both project argument and workspace option.</value>
   </data>
-  <data name="Workspace_option_is_deprecated_Use_the_project_argument_instead" xml:space="preserve">
-    <value>"workspace" option is deprecated. Use the project argument instead.</value>
+  <data name="Cannot_specify_both_project_argument_and_folder_options" xml:space="preserve">
+    <value>Cannot specify both project argument and folder options.</value>
+  </data>
+  <data name="The_workspace_option_is_deprecated_Use_the_project_argument_instead" xml:space="preserve">
+    <value>The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</value>
+  </data>
+    <data name="The_folder_option_is_deprecated_for_specifying_the_path_Pass_the_folder_option_but_specify_the_path_with_the_project_argument_instead" xml:space="preserve">
+    <value>The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</value>
+  </data>
+  <data name="The_files_option_is_deprecated_Use_the_include_option_instead" xml:space="preserve">
+    <value>The `--files` option is deprecated. Use the `--include` option instead.</value>
+  </data>
+    <data name="The_dry_run_option_is_deprecated_Use_the_check_option_instead" xml:space="preserve">
+    <value>The `--dry-run` option is deprecated. Use the `--check` option instead.</value>
   </data>
 </root>

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_folder_options">
+        <source>Cannot specify both project argument and folder options.</source>
+        <target state="new">Cannot specify both project argument and folder options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
         <source>Cannot specify both project argument and workspace option.</source>
         <target state="new">Cannot specify both project argument and workspace option.</target>
@@ -87,7 +92,7 @@
         <target state="translated">Soubory se naformátují, ale změny se neuloží na disk.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminates_with_a_non_zero_exit_code_if_any_files_were_formatted">
         <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
         <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
@@ -147,14 +152,24 @@
         <target state="new">The dotnet CLI version is '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_dry_run_option_is_deprecated_Use_the_check_option_instead">
+        <source>The `--dry-run` option is deprecated. Use the `--check` option instead.</source>
+        <target state="new">The `--dry-run` option is deprecated. Use the `--check` option instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">Soubor {0} zřejmě není platný soubor projektu nebo řešení.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
-        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
-        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
+      <trans-unit id="The_files_option_is_deprecated_Use_the_include_option_instead">
+        <source>The `--files` option is deprecated. Use the `--include` option instead.</source>
+        <target state="new">The `--files` option is deprecated. Use the `--include` option instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_option_is_deprecated_for_specifying_the_path_Pass_the_folder_option_but_specify_the_path_with_the_project_argument_instead">
+        <source>The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</source>
+        <target state="new">The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">
@@ -177,6 +192,11 @@
         <target state="new">Formatted code file '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</source>
+        <target state="new">The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>
@@ -197,9 +217,9 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
-        <source>"workspace" option is deprecated. Use the project argument instead.</source>
-        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+      <trans-unit id="Whether_to_treat_the_project_path_as_a_folder_of_files">
+        <source>Whether to treat the `&lt;project&gt;` path as a folder of files.</source>
+        <target state="new">Whether to treat the `&lt;project&gt;` path as a folder of files.</target>
         <note />
       </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_folder_options">
+        <source>Cannot specify both project argument and folder options.</source>
+        <target state="new">Cannot specify both project argument and folder options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
         <source>Cannot specify both project argument and workspace option.</source>
         <target state="new">Cannot specify both project argument and workspace option.</target>
@@ -87,7 +92,7 @@
         <target state="translated">Dateien formatieren, Änderungen aber nicht auf Festplatte speichern.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminates_with_a_non_zero_exit_code_if_any_files_were_formatted">
         <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
         <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
@@ -147,14 +152,24 @@
         <target state="new">The dotnet CLI version is '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_dry_run_option_is_deprecated_Use_the_check_option_instead">
+        <source>The `--dry-run` option is deprecated. Use the `--check` option instead.</source>
+        <target state="new">The `--dry-run` option is deprecated. Use the `--check` option instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">Die Datei "{0}" ist weder ein gültiges Projekt noch eine Projektmappendatei.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
-        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
-        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
+      <trans-unit id="The_files_option_is_deprecated_Use_the_include_option_instead">
+        <source>The `--files` option is deprecated. Use the `--include` option instead.</source>
+        <target state="new">The `--files` option is deprecated. Use the `--include` option instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_option_is_deprecated_for_specifying_the_path_Pass_the_folder_option_but_specify_the_path_with_the_project_argument_instead">
+        <source>The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</source>
+        <target state="new">The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">
@@ -177,6 +192,11 @@
         <target state="new">Formatted code file '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</source>
+        <target state="new">The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>
@@ -197,9 +217,9 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
-        <source>"workspace" option is deprecated. Use the project argument instead.</source>
-        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+      <trans-unit id="Whether_to_treat_the_project_path_as_a_folder_of_files">
+        <source>Whether to treat the `&lt;project&gt;` path as a folder of files.</source>
+        <target state="new">Whether to treat the `&lt;project&gt;` path as a folder of files.</target>
         <note />
       </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_folder_options">
+        <source>Cannot specify both project argument and folder options.</source>
+        <target state="new">Cannot specify both project argument and folder options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
         <source>Cannot specify both project argument and workspace option.</source>
         <target state="new">Cannot specify both project argument and workspace option.</target>
@@ -87,7 +92,7 @@
         <target state="translated">Formato de archivos, pero no guardar los cambios al disco.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminates_with_a_non_zero_exit_code_if_any_files_were_formatted">
         <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
         <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
@@ -147,14 +152,24 @@
         <target state="new">The dotnet CLI version is '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_dry_run_option_is_deprecated_Use_the_check_option_instead">
+        <source>The `--dry-run` option is deprecated. Use the `--check` option instead.</source>
+        <target state="new">The `--dry-run` option is deprecated. Use the `--check` option instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">El archivo "{0}" no parece ser un proyecto o archivo de solución válido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
-        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
-        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
+      <trans-unit id="The_files_option_is_deprecated_Use_the_include_option_instead">
+        <source>The `--files` option is deprecated. Use the `--include` option instead.</source>
+        <target state="new">The `--files` option is deprecated. Use the `--include` option instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_option_is_deprecated_for_specifying_the_path_Pass_the_folder_option_but_specify_the_path_with_the_project_argument_instead">
+        <source>The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</source>
+        <target state="new">The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">
@@ -177,6 +192,11 @@
         <target state="new">Formatted code file '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</source>
+        <target state="new">The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>
@@ -197,9 +217,9 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
-        <source>"workspace" option is deprecated. Use the project argument instead.</source>
-        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+      <trans-unit id="Whether_to_treat_the_project_path_as_a_folder_of_files">
+        <source>Whether to treat the `&lt;project&gt;` path as a folder of files.</source>
+        <target state="new">Whether to treat the `&lt;project&gt;` path as a folder of files.</target>
         <note />
       </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_folder_options">
+        <source>Cannot specify both project argument and folder options.</source>
+        <target state="new">Cannot specify both project argument and folder options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
         <source>Cannot specify both project argument and workspace option.</source>
         <target state="new">Cannot specify both project argument and workspace option.</target>
@@ -87,7 +92,7 @@
         <target state="translated">Mettez en forme les fichiers, mais n'enregistrez pas les changements sur le disque.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminates_with_a_non_zero_exit_code_if_any_files_were_formatted">
         <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
         <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
@@ -147,14 +152,24 @@
         <target state="new">The dotnet CLI version is '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_dry_run_option_is_deprecated_Use_the_check_option_instead">
+        <source>The `--dry-run` option is deprecated. Use the `--check` option instead.</source>
+        <target state="new">The `--dry-run` option is deprecated. Use the `--check` option instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">Le fichier '{0}' ne semble pas être un fichier projet ou solution valide.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
-        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
-        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
+      <trans-unit id="The_files_option_is_deprecated_Use_the_include_option_instead">
+        <source>The `--files` option is deprecated. Use the `--include` option instead.</source>
+        <target state="new">The `--files` option is deprecated. Use the `--include` option instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_option_is_deprecated_for_specifying_the_path_Pass_the_folder_option_but_specify_the_path_with_the_project_argument_instead">
+        <source>The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</source>
+        <target state="new">The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">
@@ -177,6 +192,11 @@
         <target state="new">Formatted code file '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</source>
+        <target state="new">The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>
@@ -197,9 +217,9 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
-        <source>"workspace" option is deprecated. Use the project argument instead.</source>
-        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+      <trans-unit id="Whether_to_treat_the_project_path_as_a_folder_of_files">
+        <source>Whether to treat the `&lt;project&gt;` path as a folder of files.</source>
+        <target state="new">Whether to treat the `&lt;project&gt;` path as a folder of files.</target>
         <note />
       </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_folder_options">
+        <source>Cannot specify both project argument and folder options.</source>
+        <target state="new">Cannot specify both project argument and folder options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
         <source>Cannot specify both project argument and workspace option.</source>
         <target state="new">Cannot specify both project argument and workspace option.</target>
@@ -87,7 +92,7 @@
         <target state="translated">Formatta i file, ma non salvare le modifiche sul disco.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminates_with_a_non_zero_exit_code_if_any_files_were_formatted">
         <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
         <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
@@ -147,14 +152,24 @@
         <target state="new">The dotnet CLI version is '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_dry_run_option_is_deprecated_Use_the_check_option_instead">
+        <source>The `--dry-run` option is deprecated. Use the `--check` option instead.</source>
+        <target state="new">The `--dry-run` option is deprecated. Use the `--check` option instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">Il file '{0}' non sembra essere un file di progetto o di soluzione valido.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
-        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
-        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
+      <trans-unit id="The_files_option_is_deprecated_Use_the_include_option_instead">
+        <source>The `--files` option is deprecated. Use the `--include` option instead.</source>
+        <target state="new">The `--files` option is deprecated. Use the `--include` option instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_option_is_deprecated_for_specifying_the_path_Pass_the_folder_option_but_specify_the_path_with_the_project_argument_instead">
+        <source>The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</source>
+        <target state="new">The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">
@@ -177,6 +192,11 @@
         <target state="new">Formatted code file '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</source>
+        <target state="new">The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>
@@ -197,9 +217,9 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
-        <source>"workspace" option is deprecated. Use the project argument instead.</source>
-        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+      <trans-unit id="Whether_to_treat_the_project_path_as_a_folder_of_files">
+        <source>Whether to treat the `&lt;project&gt;` path as a folder of files.</source>
+        <target state="new">Whether to treat the `&lt;project&gt;` path as a folder of files.</target>
         <note />
       </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_folder_options">
+        <source>Cannot specify both project argument and folder options.</source>
+        <target state="new">Cannot specify both project argument and folder options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
         <source>Cannot specify both project argument and workspace option.</source>
         <target state="new">Cannot specify both project argument and workspace option.</target>
@@ -87,7 +92,7 @@
         <target state="translated">ファイルを書式設定しますが、変更をディスクに保存しません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminates_with_a_non_zero_exit_code_if_any_files_were_formatted">
         <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
         <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
@@ -147,14 +152,24 @@
         <target state="new">The dotnet CLI version is '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_dry_run_option_is_deprecated_Use_the_check_option_instead">
+        <source>The `--dry-run` option is deprecated. Use the `--check` option instead.</source>
+        <target state="new">The `--dry-run` option is deprecated. Use the `--check` option instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">ファイル '{0}' が、有効なプロジェクト ファイルまたはソリューション ファイルではない可能性があります。</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
-        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
-        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
+      <trans-unit id="The_files_option_is_deprecated_Use_the_include_option_instead">
+        <source>The `--files` option is deprecated. Use the `--include` option instead.</source>
+        <target state="new">The `--files` option is deprecated. Use the `--include` option instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_option_is_deprecated_for_specifying_the_path_Pass_the_folder_option_but_specify_the_path_with_the_project_argument_instead">
+        <source>The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</source>
+        <target state="new">The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">
@@ -177,6 +192,11 @@
         <target state="new">Formatted code file '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</source>
+        <target state="new">The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>
@@ -197,9 +217,9 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
-        <source>"workspace" option is deprecated. Use the project argument instead.</source>
-        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+      <trans-unit id="Whether_to_treat_the_project_path_as_a_folder_of_files">
+        <source>Whether to treat the `&lt;project&gt;` path as a folder of files.</source>
+        <target state="new">Whether to treat the `&lt;project&gt;` path as a folder of files.</target>
         <note />
       </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_folder_options">
+        <source>Cannot specify both project argument and folder options.</source>
+        <target state="new">Cannot specify both project argument and folder options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
         <source>Cannot specify both project argument and workspace option.</source>
         <target state="new">Cannot specify both project argument and workspace option.</target>
@@ -87,7 +92,7 @@
         <target state="translated">파일의 형식을 지정하지만 변경 내용을 디스크에 저장하지 않습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminates_with_a_non_zero_exit_code_if_any_files_were_formatted">
         <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
         <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
@@ -147,14 +152,24 @@
         <target state="new">The dotnet CLI version is '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_dry_run_option_is_deprecated_Use_the_check_option_instead">
+        <source>The `--dry-run` option is deprecated. Use the `--check` option instead.</source>
+        <target state="new">The `--dry-run` option is deprecated. Use the `--check` option instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">'{0}' 파일은 유효한 프로젝트 또는 솔루션 파일이 아닌 것 같습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
-        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
-        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
+      <trans-unit id="The_files_option_is_deprecated_Use_the_include_option_instead">
+        <source>The `--files` option is deprecated. Use the `--include` option instead.</source>
+        <target state="new">The `--files` option is deprecated. Use the `--include` option instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_option_is_deprecated_for_specifying_the_path_Pass_the_folder_option_but_specify_the_path_with_the_project_argument_instead">
+        <source>The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</source>
+        <target state="new">The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">
@@ -177,6 +192,11 @@
         <target state="new">Formatted code file '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</source>
+        <target state="new">The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>
@@ -197,9 +217,9 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
-        <source>"workspace" option is deprecated. Use the project argument instead.</source>
-        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+      <trans-unit id="Whether_to_treat_the_project_path_as_a_folder_of_files">
+        <source>Whether to treat the `&lt;project&gt;` path as a folder of files.</source>
+        <target state="new">Whether to treat the `&lt;project&gt;` path as a folder of files.</target>
         <note />
       </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_folder_options">
+        <source>Cannot specify both project argument and folder options.</source>
+        <target state="new">Cannot specify both project argument and folder options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
         <source>Cannot specify both project argument and workspace option.</source>
         <target state="new">Cannot specify both project argument and workspace option.</target>
@@ -87,7 +92,7 @@
         <target state="translated">Formatuj pliki, ale nie zapisuj zmian na dysku.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminates_with_a_non_zero_exit_code_if_any_files_were_formatted">
         <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
         <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
@@ -147,14 +152,24 @@
         <target state="new">The dotnet CLI version is '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_dry_run_option_is_deprecated_Use_the_check_option_instead">
+        <source>The `--dry-run` option is deprecated. Use the `--check` option instead.</source>
+        <target state="new">The `--dry-run` option is deprecated. Use the `--check` option instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">Plik „{0}” prawdopodobnie nie jest prawidłowym plikiem projektu lub rozwiązania.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
-        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
-        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
+      <trans-unit id="The_files_option_is_deprecated_Use_the_include_option_instead">
+        <source>The `--files` option is deprecated. Use the `--include` option instead.</source>
+        <target state="new">The `--files` option is deprecated. Use the `--include` option instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_option_is_deprecated_for_specifying_the_path_Pass_the_folder_option_but_specify_the_path_with_the_project_argument_instead">
+        <source>The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</source>
+        <target state="new">The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">
@@ -177,6 +192,11 @@
         <target state="new">Formatted code file '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</source>
+        <target state="new">The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>
@@ -197,9 +217,9 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
-        <source>"workspace" option is deprecated. Use the project argument instead.</source>
-        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+      <trans-unit id="Whether_to_treat_the_project_path_as_a_folder_of_files">
+        <source>Whether to treat the `&lt;project&gt;` path as a folder of files.</source>
+        <target state="new">Whether to treat the `&lt;project&gt;` path as a folder of files.</target>
         <note />
       </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_folder_options">
+        <source>Cannot specify both project argument and folder options.</source>
+        <target state="new">Cannot specify both project argument and folder options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
         <source>Cannot specify both project argument and workspace option.</source>
         <target state="new">Cannot specify both project argument and workspace option.</target>
@@ -87,7 +92,7 @@
         <target state="translated">Arquivos de formato, mas não salva as alterações para o disco.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminates_with_a_non_zero_exit_code_if_any_files_were_formatted">
         <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
         <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
@@ -147,14 +152,24 @@
         <target state="new">The dotnet CLI version is '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_dry_run_option_is_deprecated_Use_the_check_option_instead">
+        <source>The `--dry-run` option is deprecated. Use the `--check` option instead.</source>
+        <target state="new">The `--dry-run` option is deprecated. Use the `--check` option instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">O arquivo '{0}' parece não ser um projeto válido ou o arquivo de solução.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
-        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
-        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
+      <trans-unit id="The_files_option_is_deprecated_Use_the_include_option_instead">
+        <source>The `--files` option is deprecated. Use the `--include` option instead.</source>
+        <target state="new">The `--files` option is deprecated. Use the `--include` option instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_option_is_deprecated_for_specifying_the_path_Pass_the_folder_option_but_specify_the_path_with_the_project_argument_instead">
+        <source>The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</source>
+        <target state="new">The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">
@@ -177,6 +192,11 @@
         <target state="new">Formatted code file '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</source>
+        <target state="new">The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>
@@ -197,9 +217,9 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
-        <source>"workspace" option is deprecated. Use the project argument instead.</source>
-        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+      <trans-unit id="Whether_to_treat_the_project_path_as_a_folder_of_files">
+        <source>Whether to treat the `&lt;project&gt;` path as a folder of files.</source>
+        <target state="new">Whether to treat the `&lt;project&gt;` path as a folder of files.</target>
         <note />
       </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_folder_options">
+        <source>Cannot specify both project argument and folder options.</source>
+        <target state="new">Cannot specify both project argument and folder options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
         <source>Cannot specify both project argument and workspace option.</source>
         <target state="new">Cannot specify both project argument and workspace option.</target>
@@ -87,7 +92,7 @@
         <target state="translated">Форматировать файлы без сохранения изменений на диск.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminates_with_a_non_zero_exit_code_if_any_files_were_formatted">
         <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
         <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
@@ -147,14 +152,24 @@
         <target state="new">The dotnet CLI version is '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_dry_run_option_is_deprecated_Use_the_check_option_instead">
+        <source>The `--dry-run` option is deprecated. Use the `--check` option instead.</source>
+        <target state="new">The `--dry-run` option is deprecated. Use the `--check` option instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">Файл "{0}" не является допустимым файлом проекта или решения.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
-        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
-        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
+      <trans-unit id="The_files_option_is_deprecated_Use_the_include_option_instead">
+        <source>The `--files` option is deprecated. Use the `--include` option instead.</source>
+        <target state="new">The `--files` option is deprecated. Use the `--include` option instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_option_is_deprecated_for_specifying_the_path_Pass_the_folder_option_but_specify_the_path_with_the_project_argument_instead">
+        <source>The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</source>
+        <target state="new">The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">
@@ -177,6 +192,11 @@
         <target state="new">Formatted code file '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</source>
+        <target state="new">The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>
@@ -197,9 +217,9 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
-        <source>"workspace" option is deprecated. Use the project argument instead.</source>
-        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+      <trans-unit id="Whether_to_treat_the_project_path_as_a_folder_of_files">
+        <source>Whether to treat the `&lt;project&gt;` path as a folder of files.</source>
+        <target state="new">Whether to treat the `&lt;project&gt;` path as a folder of files.</target>
         <note />
       </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_folder_options">
+        <source>Cannot specify both project argument and folder options.</source>
+        <target state="new">Cannot specify both project argument and folder options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
         <source>Cannot specify both project argument and workspace option.</source>
         <target state="new">Cannot specify both project argument and workspace option.</target>
@@ -87,7 +92,7 @@
         <target state="translated">Dosyaları biçimlendir, ancak değişiklikleri diske kaydetme.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminates_with_a_non_zero_exit_code_if_any_files_were_formatted">
         <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
         <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
@@ -147,14 +152,24 @@
         <target state="new">The dotnet CLI version is '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_dry_run_option_is_deprecated_Use_the_check_option_instead">
+        <source>The `--dry-run` option is deprecated. Use the `--check` option instead.</source>
+        <target state="new">The `--dry-run` option is deprecated. Use the `--check` option instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">'{0}' dosyası geçerli proje veya çözüm dosyası gibi görünmüyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
-        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
-        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
+      <trans-unit id="The_files_option_is_deprecated_Use_the_include_option_instead">
+        <source>The `--files` option is deprecated. Use the `--include` option instead.</source>
+        <target state="new">The `--files` option is deprecated. Use the `--include` option instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_option_is_deprecated_for_specifying_the_path_Pass_the_folder_option_but_specify_the_path_with_the_project_argument_instead">
+        <source>The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</source>
+        <target state="new">The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">
@@ -177,6 +192,11 @@
         <target state="new">Formatted code file '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</source>
+        <target state="new">The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>
@@ -197,9 +217,9 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
-        <source>"workspace" option is deprecated. Use the project argument instead.</source>
-        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+      <trans-unit id="Whether_to_treat_the_project_path_as_a_folder_of_files">
+        <source>Whether to treat the `&lt;project&gt;` path as a folder of files.</source>
+        <target state="new">Whether to treat the `&lt;project&gt;` path as a folder of files.</target>
         <note />
       </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_folder_options">
+        <source>Cannot specify both project argument and folder options.</source>
+        <target state="new">Cannot specify both project argument and folder options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
         <source>Cannot specify both project argument and workspace option.</source>
         <target state="new">Cannot specify both project argument and workspace option.</target>
@@ -87,7 +92,7 @@
         <target state="translated">格式化文件, 但不将更改保存到磁盘。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminates_with_a_non_zero_exit_code_if_any_files_were_formatted">
         <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
         <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
@@ -147,14 +152,24 @@
         <target state="new">The dotnet CLI version is '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_dry_run_option_is_deprecated_Use_the_check_option_instead">
+        <source>The `--dry-run` option is deprecated. Use the `--check` option instead.</source>
+        <target state="new">The `--dry-run` option is deprecated. Use the `--check` option instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">文件“{0}”似乎不是有效的项目或解决方案文件。</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
-        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
-        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
+      <trans-unit id="The_files_option_is_deprecated_Use_the_include_option_instead">
+        <source>The `--files` option is deprecated. Use the `--include` option instead.</source>
+        <target state="new">The `--files` option is deprecated. Use the `--include` option instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_option_is_deprecated_for_specifying_the_path_Pass_the_folder_option_but_specify_the_path_with_the_project_argument_instead">
+        <source>The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</source>
+        <target state="new">The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">
@@ -177,6 +192,11 @@
         <target state="new">Formatted code file '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</source>
+        <target state="new">The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>
@@ -197,9 +217,9 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
-        <source>"workspace" option is deprecated. Use the project argument instead.</source>
-        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+      <trans-unit id="Whether_to_treat_the_project_path_as_a_folder_of_files">
+        <source>Whether to treat the `&lt;project&gt;` path as a folder of files.</source>
+        <target state="new">Whether to treat the `&lt;project&gt;` path as a folder of files.</target>
         <note />
       </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -27,6 +27,11 @@
         <target state="new">Cannot specify both folder and workspace options.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Cannot_specify_both_project_argument_and_folder_options">
+        <source>Cannot specify both project argument and folder options.</source>
+        <target state="new">Cannot specify both project argument and folder options.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_specify_both_project_argument_and_workspace_option">
         <source>Cannot specify both project argument and workspace option.</source>
         <target state="new">Cannot specify both project argument and workspace option.</target>
@@ -87,7 +92,7 @@
         <target state="translated">將檔案格式化，但不儲存變更到磁碟。</target>
         <note />
       </trans-unit>
-      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminate_with_a_non_zero_exit_code_if_any_files_were_formatted">
+      <trans-unit id="Formats_files_without_saving_changes_to_disk_Terminates_with_a_non_zero_exit_code_if_any_files_were_formatted">
         <source>Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</source>
         <target state="new">Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.</target>
         <note />
@@ -147,14 +152,24 @@
         <target state="new">The dotnet CLI version is '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_dry_run_option_is_deprecated_Use_the_check_option_instead">
+        <source>The `--dry-run` option is deprecated. Use the `--check` option instead.</source>
+        <target state="new">The `--dry-run` option is deprecated. Use the `--check` option instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="The_file_0_does_not_appear_to_be_a_valid_project_or_solution_file">
         <source>The file '{0}' does not appear to be a valid project or solution file.</source>
         <target state="translated">檔案 '{0}' 似乎不是有效的專案或解決方案檔。</target>
         <note />
       </trans-unit>
-      <trans-unit id="The_folder_to_operate_on_Cannot_be_used_with_the_workspace_option">
-        <source>The folder to operate on. Cannot be used with the `--workspace` option.</source>
-        <target state="new">The folder to operate on. Cannot be used with the `--workspace` option.</target>
+      <trans-unit id="The_files_option_is_deprecated_Use_the_include_option_instead">
+        <source>The `--files` option is deprecated. Use the `--include` option instead.</source>
+        <target state="new">The `--files` option is deprecated. Use the `--include` option instead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_folder_option_is_deprecated_for_specifying_the_path_Pass_the_folder_option_but_specify_the_path_with_the_project_argument_instead">
+        <source>The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</source>
+        <target state="new">The `--folder` option is deprecated for specifying the path. Pass the `--folder` option but specify the path with the project argument instead.</target>
         <note />
       </trans-unit>
       <trans-unit id="The_project_file_0_does_not_exist">
@@ -177,6 +192,11 @@
         <target state="new">Formatted code file '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="The_workspace_option_is_deprecated_Use_the_project_argument_instead">
+        <source>The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</source>
+        <target state="new">The `--workspace` option is deprecated. Use the `&lt;project&gt;` argument instead.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>
@@ -197,9 +217,9 @@
         <target state="new">Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.</target>
         <note />
       </trans-unit>
-      <trans-unit id="Workspace_option_is_deprecated_Use_the_project_argument_instead">
-        <source>"workspace" option is deprecated. Use the project argument instead.</source>
-        <target state="new">"workspace" option is deprecated. Use the project argument instead.</target>
+      <trans-unit id="Whether_to_treat_the_project_path_as_a_folder_of_files">
+        <source>Whether to treat the `&lt;project&gt;` path as a folder of files.</source>
+        <target state="new">Whether to treat the `&lt;project&gt;` path as a folder of files.</target>
         <note />
       </trans-unit>
       <trans-unit id="Writing_formatting_report_to_0">

--- a/tests/ProgramTests.cs
+++ b/tests/ProgramTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         public void CommandLine_OptionsAreParsedCorrectly()
         {
             // Arrange
-            var sut = Program.CreateCommandLineOptions();
+            var sut = FormatCommand.CreateCommandLineOptions();
 
             // Act
             var result = sut.Parse(new[] {
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         public void CommandLine_ProjectArgument_Simple()
         {
             // Arrange
-            var sut = Program.CreateCommandLineOptions();
+            var sut = FormatCommand.CreateCommandLineOptions();
 
             // Act
             var result = sut.Parse(new[] { "projectValue" });
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         public void CommandLine_ProjectArgument_WithOption_AfterArgument()
         {
             // Arrange
-            var sut = Program.CreateCommandLineOptions();
+            var sut = FormatCommand.CreateCommandLineOptions();
 
             // Act
             var result = sut.Parse(new[] { "projectValue", "--verbosity", "verbosity" });
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         public void CommandLine_ProjectArgument_WithOption_BeforeArgument()
         {
             // Arrange
-            var sut = Program.CreateCommandLineOptions();
+            var sut = FormatCommand.CreateCommandLineOptions();
 
             // Act
             var result = sut.Parse(new[] { "--verbosity", "verbosity", "projectValue" });
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         public void CommandLine_ProjectArgument_GetsPassedToHandler()
         {
             // Arrange
-            var sut = Program.CreateCommandLineOptions();
+            var sut = FormatCommand.CreateCommandLineOptions();
             var handlerWasCalled = false;
             sut.Handler = CommandHandler.Create(new TestCommandHandlerDelegate(TestCommandHandler));
 
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         public void CommandLine_ProjectArgument_FailesIfSpecifiedTwice()
         {
             // Arrange
-            var sut = Program.CreateCommandLineOptions();
+            var sut = FormatCommand.CreateCommandLineOptions();
 
             // Act
             var result = sut.Parse(new[] { "projectValue1", "projectValue2" });
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         public void CommandLine_ProjectArgumentAndWorkspaceCanNotBeCombined()
         {
             // Arrange
-            var sut = Program.CreateCommandLineOptions();
+            var sut = FormatCommand.CreateCommandLineOptions();
 
             // Act
             var result = sut.Parse(new[] { "projectValue", "--workspace", "workspace" });
@@ -170,10 +170,10 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         }
 
         [Fact]
-        public void CommandLine_ProjectWorkspaceAndFolderCanNotBeCombined1()
+        public void CommandLine_ProjectArgumentAndFolderCanNotBeCombined1()
         {
             // Arrange
-            var sut = Program.CreateCommandLineOptions();
+            var sut = FormatCommand.CreateCommandLineOptions();
 
             // Act
             var result = sut.Parse(new[] { "projectValue", "--folder", "folder" });
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         public void CommandLine_ProjectWorkspaceAndFolderCanNotBeCombined2()
         {
             // Arrange
-            var sut = Program.CreateCommandLineOptions();
+            var sut = FormatCommand.CreateCommandLineOptions();
 
             // Act
             var result = sut.Parse(new[] { "--workspace", "workspace", "--folder", "folder" });
@@ -199,7 +199,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         public void CommandLine_InvalidArgumentsDontCrashTheValidators()
         {
             // Arrange
-            var sut = Program.CreateCommandLineOptions();
+            var sut = FormatCommand.CreateCommandLineOptions();
 
             // Act
             var result = sut.Parse(new[] { "--workspace", "workspace1", "--workspace", "workspace2" });


### PR DESCRIPTION
- Moves the root command definition and validators to a separate class.
- Hides the `--workspace` option.
- Deprecates specifying the folder path via the `--folder` option. Warning is shown to specify the path via the `<project>` argument and to simply use `--folder` as a flag.
- Warning is shown when using `--dry-run` instead of `--check`.
- Warning is shown when using `--files` instead of `--include`.

The plan would be to remove the warnings and alias options after the 4.x release.