### PR TITLE
Bump System.CommandLine version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -16,8 +16,8 @@
     Other Dependency versions
   -->
   <PropertyGroup>
-    <SystemCommandLineVersion>2.0.0-beta1.20104.2</SystemCommandLineVersion>
-    <SystemCommandLineRenderingVersion>0.3.0-alpha.20104.2</SystemCommandLineRenderingVersion>
+    <SystemCommandLineVersion>2.0.0-beta1.20303.1</SystemCommandLineVersion>
+    <SystemCommandLineRenderingVersion>0.3.0-alpha.20303.1</SystemCommandLineRenderingVersion>
     <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildVersion)</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildLocatorVersion>1.2.6</MicrosoftBuildLocatorVersion>
     <MicrosoftCodeAnalysisAnalyzerTestingVersion>1.0.1-beta1.20114.4</MicrosoftCodeAnalysisAnalyzerTestingVersion>

--- a/tests/ProgramTests.cs
+++ b/tests/ProgramTests.cs
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
             var result = sut.Parse(new[] { "--workspace", "workspace1", "--workspace", "workspace2" });
 
             // Assert
-            Assert.Equal(1, result.Errors.Count);
+            Assert.Equal(2, result.Errors.Count);
         }
     }
 }


### PR DESCRIPTION
This build contains a fix (https://github.com/dotnet/command-line-api/issues/863) that removes the 255 argument limit for OneOrMany options such as our `--include` and `--exclude` options.