### PR TITLE
Add devcontainer to better support Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,71 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+ARG VARIANT="3.1-bionic"
+FROM mcr.microsoft.com/dotnet/core/sdk:${VARIANT}
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Options for common package install script
+ARG INSTALL_ZSH="true"
+ARG UPGRADE_PACKAGES="true"
+ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/v0.126.0/script-library/common-debian.sh"
+ARG COMMON_SCRIPT_SHA="a6bfacc5c9c6c3706adc8788bf70182729767955b7a5509598ac205ce6847e1e"
+
+# [Optional] Settings for installing Node.js.
+ARG INSTALL_NODE="true"
+ARG NODE_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/node-debian.sh"
+ARG NODE_SCRIPT_SHA="dev-mode"
+ARG NODE_VERSION="lts/*"
+ENV NVM_DIR=/usr/local/share/nvm
+# Have nvm create a "current" symlink and add to path to work around https://github.com/microsoft/vscode-remote-release/issues/3224
+ENV NVM_SYMLINK_CURRENT=true
+ENV PATH=${NVM_DIR}/current/bin:${PATH}
+
+# [Optional] Install the Azure CLI
+ARG INSTALL_AZURE_CLI="false"
+ARG INSTALL_POSHGIT="true"
+
+# Configure apt and install packages
+RUN apt-get update \
+    && export DEBIAN_FRONTEND=noninteractive \
+    #
+    # Verify git, common tools / libs installed, add/modify non-root user, optionally install zsh
+    && apt-get -y install --no-install-recommends curl ca-certificates 2>&1 \
+    && curl -sSL ${COMMON_SCRIPT_SOURCE} -o /tmp/common-setup.sh \
+    && ([ "${COMMON_SCRIPT_SHA}" = "dev-mode" ] || (echo "${COMMON_SCRIPT_SHA} */tmp/common-setup.sh" | sha256sum -c -)) \
+    && /bin/bash /tmp/common-setup.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
+    #
+    # [Optional] Install Node.js for ASP.NET Core Web Applicationss
+    && if [ "$INSTALL_NODE" = "true" ]; then \
+        curl -sSL ${NODE_SCRIPT_SOURCE} -o /tmp/node-setup.sh \
+        && ([ "${NODE_SCRIPT_SHA}" = "dev-mode" ] || (echo "${COMMON_SCRIPT_SHA} */tmp/node-setup.sh" | sha256sum -c -)) \
+        && /bin/bash /tmp/node-setup.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; \
+    fi \
+    #
+    # [Optional] Install the Azure CLI
+    && if [ "$INSTALL_AZURE_CLI" = "true" ]; then \
+        echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
+        && curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - 2>/dev/null \
+        && apt-get update \
+        && apt-get install -y azure-cli; \
+    fi \
+    #
+    # [Optional] Install the Posh-Git
+    && if [ "$INSTALL_POSHGIT" = "true" ]; then \
+        pwsh -command "PowerShellGet\Install-Module posh-git -Scope CurrentUser -AllowPrerelease -Force" \
+        && pwsh -command "Add-PoshGitToProfile -AllHosts"; \
+    fi \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -f /tmp/common-setup.sh /tmp/node-setup.sh \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,53 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.126.0/containers/dotnetcore
+{
+  "name": "C# (.NET Core)",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      // Update 'VARIANT' to pick a .NET Core version. Rebuild the container if
+      // it already exists to update. Example variants: 2.1-bionic, 3.1-bionic
+      "VARIANT": "3.1-bionic",
+      // Options
+      "INSTALL_NODE": "false",
+      "NODE_VERSION": "lts/*",
+      "INSTALL_ZSH": "false",
+      "INSTALL_AZURE_CLI": "false",
+      "UPGRADE_PACKAGES": "false",
+      "INSTALL_POSHGIT": "true"
+    }
+  },
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "terminal.integrated.shell.linux": "/usr/bin/pwsh"
+  },
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "ms-dotnettools.csharp",
+    "editorconfig.editorconfig",
+    "tintoy.msbuild-project-tools",
+    "ms-vscode.powershell"
+  ],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [5000, 5001],
+  // [Optional] To reuse of your local HTTPS dev cert, first export it locally using this command:
+  //  * Windows PowerShell:
+  //     dotnet dev-certs https --trust; dotnet dev-certs https -ep "$env:USERPROFILE/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+  //  * macOS/Linux terminal:
+  //     dotnet dev-certs https --trust; dotnet dev-certs https -ep "${HOME}/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+  //
+  // Next, after running the command above, uncomment lines in the 'mounts' and 'remoteEnv' lines below,
+  // and open / rebuild the container so the settings take effect.
+  //
+  "mounts": [
+    // "source=${env:HOME}${env:USERPROFILE}/.aspnet/https,target=/home/vscode/.aspnet/https,type=bind"
+  ],
+  "remoteEnv": {
+    // "ASPNETCORE_Kestrel__Certificates__Default__Password": "SecurePwdGoesHere",
+    // "ASPNETCORE_Kestrel__Certificates__Default__Path": "/home/vscode/.aspnet/https/aspnetapp.pfx",
+  },
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "./restore.sh",
+  // Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+  // "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,6 +25,7 @@
   "extensions": [
     "ms-dotnettools.csharp",
     "editorconfig.editorconfig",
+    "formulahendry.dotnet-test-explorer",
     "tintoy.msbuild-project-tools",
     "ms-vscode.powershell"
   ],


### PR DESCRIPTION
Takes the base .NET Core devcontainer and tweaks it a bit to avoid installing unnecessary dependencies and to run `./restore.sh`.