### PR TITLE
Run all analyzers even when a fixer isn't present

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -131,6 +131,7 @@ csharp_indent_switch_labels = true
 csharp_indent_labels = flush_left
 
 # Prefer "var" everywhere
+dotnet_diagnostic.IDE0007.severity = error
 csharp_style_var_for_built_in_types = true:error
 csharp_style_var_when_type_is_apparent = true:error
 csharp_style_var_elsewhere = true:error
@@ -178,3 +179,35 @@ csharp_space_between_parentheses = false
 csharp_prefer_braces = true:silent
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = true
+
+# IDE0073: File header
+dotnet_diagnostic.IDE0073.severity = warning
+file_header_template = Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+# IDE0035: Remove unreachable code
+dotnet_diagnostic.IDE0035.severity = warning
+
+# IDE0036: Order modifiers
+dotnet_diagnostic.IDE0036.severity = warning
+
+# IDE0040: Add accessibility modifiers
+dotnet_diagnostic.IDE0040.severity = warning
+
+# IDE0043: Format string contains invalid placeholder
+dotnet_diagnostic.IDE0043.severity = warning
+
+# IDE0044: Make field readonly
+dotnet_diagnostic.IDE0044.severity = warning
+
+# CONSIDER: Are IDE0051 and IDE0052 too noisy to be warnings for IDE editing scenarios? Should they be made build-only warnings?
+# IDE0051: Remove unused private member
+dotnet_diagnostic.IDE0051.severity = warning
+
+# IDE0052: Remove unread private member
+dotnet_diagnostic.IDE0052.severity = warning
+
+# IDE0059: Unnecessary assignment to a value
+dotnet_diagnostic.IDE0059.severity = warning
+
+# IDE0060: Remove unused parameter
+dotnet_diagnostic.IDE0060.severity = warning

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,9 +44,9 @@
       "name": "format format.sln --fix-style --check",
       "type": "coreclr",
       "request": "launch",
-      "preLaunchTask": "publish",
+      "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/artifacts/bin/dotnet-format/Debug/netcoreapp2.1/publish/dotnet-format.dll",
+      "program": "${workspaceFolder}/artifacts/bin/dotnet-format/Debug/netcoreapp2.1/dotnet-format.dll",
       "args": [
         "format.sln",
         "--fix-style",
@@ -63,9 +63,9 @@
       "name": "format format.sln --fix-analyzers warn --check",
       "type": "coreclr",
       "request": "launch",
-      "preLaunchTask": "publish",
+      "preLaunchTask": "build",
       // If you have changed target frameworks, make sure to update the program path.
-      "program": "${workspaceFolder}/artifacts/bin/dotnet-format/Debug/netcoreapp2.1/publish/dotnet-format.dll",
+      "program": "${workspaceFolder}/artifacts/bin/dotnet-format/Debug/netcoreapp2.1/dotnet-format.dll",
       "args": [
         "format.sln",
         "--fix-analyzers",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -41,7 +41,7 @@
       "stopAtEntry": false
     },
     {
-      "name": "format format.sln --fix-style --check",
+      "name": "format format.sln --fix-style warn --check",
       "type": "coreclr",
       "request": "launch",
       "preLaunchTask": "build",
@@ -50,6 +50,7 @@
       "args": [
         "format.sln",
         "--fix-style",
+        "warn",
         "-v",
         "diag",
         "--check"

--- a/src/Analyzers/AnalyzerFinderHelpers.cs
+++ b/src/Analyzers/AnalyzerFinderHelpers.cs
@@ -12,7 +12,12 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
 {
     internal static class AnalyzerFinderHelpers
     {
-        public static ImmutableArray<(DiagnosticAnalyzer Analyzer, CodeFixProvider? Fixer)> LoadAnalyzersAndFixers(IEnumerable<Assembly> assemblies)
+        public static DiagnosticAnalyzer? GetAnalyzer(string name)
+        {
+            return null;
+        }
+
+        public static (ImmutableArray<DiagnosticAnalyzer> Analyzers, ImmutableArray<CodeFixProvider> Fixers) LoadAnalyzersAndFixers(IEnumerable<Assembly> assemblies)
         {
             var types = assemblies
                 .SelectMany(assembly => assembly.GetTypes()
@@ -32,21 +37,7 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
                 .OfType<DiagnosticAnalyzer>()
                 .ToImmutableArray();
 
-            var builder = ImmutableArray.CreateBuilder<(DiagnosticAnalyzer Analyzer, CodeFixProvider? Fixer)>();
-            foreach (var diagnosticAnalyzer in diagnosticAnalyzers)
-            {
-                var diagnosticIds = diagnosticAnalyzer.SupportedDiagnostics.Select(diagnostic => diagnostic.Id).ToImmutableHashSet();
-                var codeFixProvider = codeFixProviders.FirstOrDefault(codeFixProvider => codeFixProvider.FixableDiagnosticIds.Any(id => diagnosticIds.Contains(id)));
-
-                if (codeFixProvider is null)
-                {
-                    continue;
-                }
-
-                builder.Add((diagnosticAnalyzer, codeFixProvider));
-            }
-
-            return builder.ToImmutableArray();
+            return (diagnosticAnalyzers, codeFixProviders);
         }
     }
 }

--- a/src/Analyzers/AnalyzerFinderHelpers.cs
+++ b/src/Analyzers/AnalyzerFinderHelpers.cs
@@ -12,11 +12,6 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
 {
     internal static class AnalyzerFinderHelpers
     {
-        public static DiagnosticAnalyzer? GetAnalyzer(string name)
-        {
-            return null;
-        }
-
         public static (ImmutableArray<DiagnosticAnalyzer> Analyzers, ImmutableArray<CodeFixProvider> Fixers) LoadAnalyzersAndFixers(IEnumerable<Assembly> assemblies)
         {
             var types = assemblies

--- a/src/Analyzers/AnalyzerFinderHelpers.cs
+++ b/src/Analyzers/AnalyzerFinderHelpers.cs
@@ -4,8 +4,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -49,33 +47,6 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
             }
 
             return builder.ToImmutableArray();
-        }
-
-        public static async Task<ImmutableDictionary<Project, ImmutableArray<DiagnosticAnalyzer>>> FilterBySeverityAsync(
-            IEnumerable<Project> projects,
-            ImmutableArray<DiagnosticAnalyzer> allAnalyzers,
-            ImmutableHashSet<string> formattablePaths,
-            DiagnosticSeverity minimumSeverity,
-            CancellationToken cancellationToken)
-        {
-            var projectAnalyzers = ImmutableDictionary.CreateBuilder<Project, ImmutableArray<DiagnosticAnalyzer>>();
-            foreach (var project in projects)
-            {
-                var analyzers = ImmutableArray.CreateBuilder<DiagnosticAnalyzer>();
-
-                foreach (var analyzer in allAnalyzers)
-                {
-                    var severity = await analyzer.GetSeverityAsync(project, formattablePaths, cancellationToken).ConfigureAwait(false);
-                    if (severity >= minimumSeverity)
-                    {
-                        analyzers.Add(analyzer);
-                    }
-                }
-
-                projectAnalyzers.Add(project, analyzers.ToImmutableArray());
-            }
-
-            return projectAnalyzers.ToImmutableDictionary();
         }
     }
 }

--- a/src/Analyzers/AnalyzerFormatter.cs
+++ b/src/Analyzers/AnalyzerFormatter.cs
@@ -23,12 +23,12 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
 
         public AnalyzerFormatter(
             string name,
-            IAnalyzerInformationProvider finder,
+            IAnalyzerInformationProvider informationProvider,
             IAnalyzerRunner runner,
             ICodeFixApplier applier)
         {
             _name = name;
-            _informationProvider = finder;
+            _informationProvider = informationProvider;
             _runner = runner;
             _applier = applier;
         }

--- a/src/Analyzers/AnalyzerOptionExtensions.cs
+++ b/src/Analyzers/AnalyzerOptionExtensions.cs
@@ -1,6 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
 using System.Linq;

--- a/src/Analyzers/AnalyzerOptionExtensions.cs
+++ b/src/Analyzers/AnalyzerOptionExtensions.cs
@@ -44,14 +44,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return false;
             }
 
-            // If user has explicitly configured severity for this diagnostic ID, that should be respected and
-            // bulk configuration should not be applied.
-            // For example, 'dotnet_diagnostic.CA1000.severity = error'
-            if (compilation.Options.SpecificDiagnosticOptions.ContainsKey(descriptor.Id) ||
-                tree.DiagnosticOptions.ContainsKey(descriptor.Id))
+            // If user has explicitly configured severity for this diagnostic ID, that should be respected.
+            if (compilation.Options.SpecificDiagnosticOptions.TryGetValue(descriptor.Id, out severity))
             {
-                severity = default;
-                return false;
+                return true;
+            }
+
+            // If user has explicitly configured severity for this diagnostic ID, that should be respected.
+            // For example, 'dotnet_diagnostic.CA1000.severity = error'
+            if (tree.DiagnosticOptions.TryGetValue(descriptor.Id, out severity))
+            {
+                return true;
             }
 
             var analyzerConfigOptions = analyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(tree);

--- a/src/Analyzers/AnalyzerReferenceInformationProvider.cs
+++ b/src/Analyzers/AnalyzerReferenceInformationProvider.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -13,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools.Analyzers
 {
-    internal class AnalyzerReferenceAnalyzerFinder : IAnalyzerFinder
+    internal class AnalyzerReferenceInformationProvider : IAnalyzerInformationProvider
     {
         public ImmutableArray<(DiagnosticAnalyzer Analyzer, CodeFixProvider? Fixer)> GetAnalyzersAndFixers(
             Solution solution,
@@ -33,14 +30,6 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
             return AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
         }
 
-        public Task<ImmutableDictionary<Project, ImmutableArray<DiagnosticAnalyzer>>> FilterBySeverityAsync(
-            IEnumerable<Project> projects,
-            ImmutableArray<DiagnosticAnalyzer> allAnalyzers,
-            ImmutableHashSet<string> formattablePaths,
-            FormatOptions formatOptions,
-            CancellationToken cancellationToken)
-        {
-            return AnalyzerFinderHelpers.FilterBySeverityAsync(projects, allAnalyzers, formattablePaths, formatOptions.AnalyzerSeverity, cancellationToken);
-        }
+        public DiagnosticSeverity GetSeverity(FormatOptions formatOptions) => formatOptions.AnalyzerSeverity;
     }
 }

--- a/src/Analyzers/AnalyzerReferenceInformationProvider.cs
+++ b/src/Analyzers/AnalyzerReferenceInformationProvider.cs
@@ -12,14 +12,14 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
 {
     internal class AnalyzerReferenceInformationProvider : IAnalyzerInformationProvider
     {
-        public ImmutableArray<(DiagnosticAnalyzer Analyzer, CodeFixProvider? Fixer)> GetAnalyzersAndFixers(
+        public (ImmutableArray<DiagnosticAnalyzer> Analyzers, ImmutableArray<CodeFixProvider> Fixers) GetAnalyzersAndFixers(
             Solution solution,
             FormatOptions formatOptions,
             ILogger logger)
         {
             if (!formatOptions.FixAnalyzers)
             {
-                return ImmutableArray<(DiagnosticAnalyzer Analyzer, CodeFixProvider? Fixer)>.Empty;
+                return (ImmutableArray<DiagnosticAnalyzer>.Empty, ImmutableArray<CodeFixProvider>.Empty);
             }
 
             var assemblies = solution.Projects

--- a/src/Analyzers/AnalyzerRunner.cs
+++ b/src/Analyzers/AnalyzerRunner.cs
@@ -11,6 +11,13 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
 {
     internal partial class AnalyzerRunner : IAnalyzerRunner
     {
+        private bool _includeComplilerDiagnostics;
+
+        public AnalyzerRunner(bool includeCompilerDiagnostics)
+        {
+            _includeComplilerDiagnostics = includeCompilerDiagnostics;
+        }
+
         public Task RunCodeAnalysisAsync(
             CodeAnalysisResult result,
             DiagnosticAnalyzer analyzers,
@@ -36,14 +43,31 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
                 return;
             }
 
-            var analyzerOptions = new CompilationWithAnalyzersOptions(
-                project.AnalyzerOptions,
-                onAnalyzerException: null,
-                concurrentAnalysis: true,
-                logAnalyzerExecutionTime: false,
-                reportSuppressedDiagnostics: false);
-            var analyzerCompilation = compilation.WithAnalyzers(analyzers, analyzerOptions);
-            var diagnostics = await analyzerCompilation.GetAnalyzerDiagnosticsAsync(cancellationToken).ConfigureAwait(false);
+            // If are not running any analyzers and are not reporting compiler diagnostics, then there is
+            // nothing to report.
+            if (analyzers.IsEmpty && !_includeComplilerDiagnostics)
+            {
+                return;
+            }
+
+            ImmutableArray<Diagnostic> diagnostics;
+            if (analyzers.IsEmpty)
+            {
+                diagnostics = compilation.GetDiagnostics(cancellationToken);
+            }
+            else
+            {
+                var analyzerOptions = new CompilationWithAnalyzersOptions(
+                    project.AnalyzerOptions,
+                    onAnalyzerException: null,
+                    concurrentAnalysis: true,
+                    logAnalyzerExecutionTime: false,
+                    reportSuppressedDiagnostics: false);
+                var analyzerCompilation = compilation.WithAnalyzers(analyzers, analyzerOptions);
+                diagnostics = _includeComplilerDiagnostics
+                    ? await analyzerCompilation.GetAllDiagnosticsAsync(cancellationToken).ConfigureAwait(false)
+                    : await analyzerCompilation.GetAnalyzerDiagnosticsAsync(cancellationToken).ConfigureAwait(false);
+            }
 
             // filter diagnostics
             foreach (var diagnostic in diagnostics)

--- a/src/Analyzers/AnalyzerRunner.cs
+++ b/src/Analyzers/AnalyzerRunner.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
 {
     internal partial class AnalyzerRunner : IAnalyzerRunner
     {
-        private bool _includeComplilerDiagnostics;
+        private readonly bool _includeComplilerDiagnostics;
 
         public AnalyzerRunner(bool includeCompilerDiagnostics)
         {

--- a/src/Analyzers/AnalyzerRunner.cs
+++ b/src/Analyzers/AnalyzerRunner.cs
@@ -16,15 +16,17 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
             DiagnosticAnalyzer analyzers,
             Project project,
             ImmutableHashSet<string> formattableDocumentPaths,
+            DiagnosticSeverity severity,
             ILogger logger,
             CancellationToken cancellationToken)
-            => RunCodeAnalysisAsync(result, ImmutableArray.Create(analyzers), project, formattableDocumentPaths, logger, cancellationToken);
+            => RunCodeAnalysisAsync(result, ImmutableArray.Create(analyzers), project, formattableDocumentPaths, severity, logger, cancellationToken);
 
         public async Task RunCodeAnalysisAsync(
             CodeAnalysisResult result,
             ImmutableArray<DiagnosticAnalyzer> analyzers,
             Project project,
             ImmutableHashSet<string> formattableDocumentPaths,
+            DiagnosticSeverity severity,
             ILogger logger,
             CancellationToken cancellationToken)
         {
@@ -47,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
             foreach (var diagnostic in diagnostics)
             {
                 if (!diagnostic.IsSuppressed &&
-                    diagnostic.Severity >= DiagnosticSeverity.Warning &&
+                    diagnostic.Severity >= severity &&
                     diagnostic.Location.IsInSource &&
                     diagnostic.Location.SourceTree != null &&
                     formattableDocumentPaths.Contains(diagnostic.Location.SourceTree.FilePath))

--- a/src/Analyzers/CodeStyleInformationProvider.cs
+++ b/src/Analyzers/CodeStyleInformationProvider.cs
@@ -18,14 +18,14 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
         private readonly string _featuresCSharpPath = Path.Combine(s_executingPath, "Microsoft.CodeAnalysis.CSharp.Features.dll");
         private readonly string _featuresVisualBasicPath = Path.Combine(s_executingPath, "Microsoft.CodeAnalysis.VisualBasic.Features.dll");
 
-        public ImmutableArray<(DiagnosticAnalyzer Analyzer, CodeFixProvider? Fixer)> GetAnalyzersAndFixers(
+        public (ImmutableArray<DiagnosticAnalyzer> Analyzers, ImmutableArray<CodeFixProvider> Fixers) GetAnalyzersAndFixers(
             Solution solution,
             FormatOptions options,
             ILogger logger)
         {
             if (!options.FixCodeStyle)
             {
-                return ImmutableArray<(DiagnosticAnalyzer Analyzer, CodeFixProvider? Fixer)>.Empty;
+                return (ImmutableArray<DiagnosticAnalyzer>.Empty, ImmutableArray<CodeFixProvider>.Empty);
             }
 
             var assemblies = new[]

--- a/src/Analyzers/CodeStyleInformationProvider.cs
+++ b/src/Analyzers/CodeStyleInformationProvider.cs
@@ -1,22 +1,20 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools.Analyzers
 {
-    internal class RoslynCodeStyleAnalyzerFinder : IAnalyzerFinder
+    internal class CodeStyleInformationProvider : IAnalyzerInformationProvider
     {
         private static readonly string s_executingPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
+        private readonly string _featuresPath = Path.Combine(s_executingPath, "Microsoft.CodeAnalysis.Features.dll");
         private readonly string _featuresCSharpPath = Path.Combine(s_executingPath, "Microsoft.CodeAnalysis.CSharp.Features.dll");
         private readonly string _featuresVisualBasicPath = Path.Combine(s_executingPath, "Microsoft.CodeAnalysis.VisualBasic.Features.dll");
 
@@ -32,6 +30,7 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
 
             var assemblies = new[]
             {
+                _featuresPath,
                 _featuresCSharpPath,
                 _featuresVisualBasicPath
             }.Select(path => Assembly.LoadFrom(path));
@@ -39,14 +38,6 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
             return AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
         }
 
-        public Task<ImmutableDictionary<Project, ImmutableArray<DiagnosticAnalyzer>>> FilterBySeverityAsync(
-            IEnumerable<Project> projects,
-            ImmutableArray<DiagnosticAnalyzer> allAnalyzers,
-            ImmutableHashSet<string> formattablePaths,
-            FormatOptions formatOptions,
-            CancellationToken cancellationToken)
-        {
-            return AnalyzerFinderHelpers.FilterBySeverityAsync(projects, allAnalyzers, formattablePaths, formatOptions.CodeStyleSeverity, cancellationToken);
-        }
+        public DiagnosticSeverity GetSeverity(FormatOptions formatOptions) => formatOptions.CodeStyleSeverity;
     }
 }

--- a/src/Analyzers/Interfaces/IAnalyzerInformationProvider.cs
+++ b/src/Analyzers/Interfaces/IAnalyzerInformationProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools.Analyzers
 {
-    interface IAnalyzerInformationProvider
+    internal interface IAnalyzerInformationProvider
     {
         DiagnosticSeverity GetSeverity(FormatOptions formatOptions);
 

--- a/src/Analyzers/Interfaces/IAnalyzerInformationProvider.cs
+++ b/src/Analyzers/Interfaces/IAnalyzerInformationProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
     {
         DiagnosticSeverity GetSeverity(FormatOptions formatOptions);
 
-        ImmutableArray<(DiagnosticAnalyzer Analyzer, CodeFixProvider? Fixer)> GetAnalyzersAndFixers(
+        (ImmutableArray<DiagnosticAnalyzer> Analyzers, ImmutableArray<CodeFixProvider> Fixers) GetAnalyzersAndFixers(
             Solution solution,
             FormatOptions formatOptions,
             ILogger logger);

--- a/src/Analyzers/Interfaces/IAnalyzerInformationProvider.cs
+++ b/src/Analyzers/Interfaces/IAnalyzerInformationProvider.cs
@@ -1,27 +1,19 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools.Analyzers
 {
-    interface IAnalyzerFinder
+    interface IAnalyzerInformationProvider
     {
+        DiagnosticSeverity GetSeverity(FormatOptions formatOptions);
+
         ImmutableArray<(DiagnosticAnalyzer Analyzer, CodeFixProvider? Fixer)> GetAnalyzersAndFixers(
             Solution solution,
             FormatOptions formatOptions,
             ILogger logger);
-
-        Task<ImmutableDictionary<Project, ImmutableArray<DiagnosticAnalyzer>>> FilterBySeverityAsync(
-            IEnumerable<Project> projects,
-            ImmutableArray<DiagnosticAnalyzer> allAnalyzers,
-            ImmutableHashSet<string> formattablePaths,
-            FormatOptions formatOptions,
-            CancellationToken cancellationToken);
     }
 }

--- a/src/Analyzers/Interfaces/IAnalyzerRunner.cs
+++ b/src/Analyzers/Interfaces/IAnalyzerRunner.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
             DiagnosticAnalyzer analyzers,
             Project project,
             ImmutableHashSet<string> formattableDocumentPaths,
+            DiagnosticSeverity severity,
             ILogger logger,
             CancellationToken cancellationToken);
 
@@ -23,6 +24,7 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
             ImmutableArray<DiagnosticAnalyzer> analyzers,
             Project project,
             ImmutableHashSet<string> formattableDocumentPaths,
+            DiagnosticSeverity severity,
             ILogger logger,
             CancellationToken cancellationToken);
     }

--- a/src/Analyzers/Interfaces/IAnalyzerRunner.cs
+++ b/src/Analyzers/Interfaces/IAnalyzerRunner.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools.Analyzers
 {
-    interface IAnalyzerRunner
+    internal interface IAnalyzerRunner
     {
         Task RunCodeAnalysisAsync(
             CodeAnalysisResult result,

--- a/src/Analyzers/Interfaces/ICodeFixApplier.cs
+++ b/src/Analyzers/Interfaces/ICodeFixApplier.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools.Analyzers
 {
-    interface ICodeFixApplier
+    internal interface ICodeFixApplier
     {
         Task<Solution> ApplyCodeFixesAsync(
             Solution solution,

--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Tools
             new CharsetFormatter(),
             new ImportsFormatter(),
             new AnalyzerFormatter(Resources.Code_Style, new CodeStyleInformationProvider(), new AnalyzerRunner(includeCompilerDiagnostics: true), new SolutionCodeFixApplier()),
-            new AnalyzerFormatter(Resources.Analyzer_Reference, new AnalyzerReferenceInformationProvider(), new AnalyzerRunner(includeCompilerDiagnostics: false), new SolutionCodeFixApplier()),
+            new AnalyzerFormatter(Resources.Analyzer_Reference, new AnalyzerReferenceInformationProvider(), new AnalyzerRunner(includeCompilerDiagnostics: true), new SolutionCodeFixApplier()),
         }.ToImmutableArray();
 
         public static async Task<WorkspaceFormatResult> FormatWorkspaceAsync(

--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -29,8 +29,8 @@ namespace Microsoft.CodeAnalysis.Tools
             new EndOfLineFormatter(),
             new CharsetFormatter(),
             new ImportsFormatter(),
-            new AnalyzerFormatter(Resources.Code_Style, new CodeStyleInformationProvider(), new AnalyzerRunner(), new SolutionCodeFixApplier()),
-            new AnalyzerFormatter(Resources.Analyzer_Reference, new AnalyzerReferenceInformationProvider(), new AnalyzerRunner(), new SolutionCodeFixApplier()),
+            new AnalyzerFormatter(Resources.Code_Style, new CodeStyleInformationProvider(), new AnalyzerRunner(includeCompilerDiagnostics: true), new SolutionCodeFixApplier()),
+            new AnalyzerFormatter(Resources.Analyzer_Reference, new AnalyzerReferenceInformationProvider(), new AnalyzerRunner(includeCompilerDiagnostics: false), new SolutionCodeFixApplier()),
         }.ToImmutableArray();
 
         public static async Task<WorkspaceFormatResult> FormatWorkspaceAsync(

--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -29,8 +29,8 @@ namespace Microsoft.CodeAnalysis.Tools
             new EndOfLineFormatter(),
             new CharsetFormatter(),
             new ImportsFormatter(),
-            new AnalyzerFormatter(Resources.Code_Style, new RoslynCodeStyleAnalyzerFinder(), new AnalyzerRunner(), new SolutionCodeFixApplier()),
-            new AnalyzerFormatter(Resources.Analyzer_Reference, new AnalyzerReferenceAnalyzerFinder(), new AnalyzerRunner(), new SolutionCodeFixApplier()),
+            new AnalyzerFormatter(Resources.Code_Style, new CodeStyleInformationProvider(), new AnalyzerRunner(), new SolutionCodeFixApplier()),
+            new AnalyzerFormatter(Resources.Analyzer_Reference, new AnalyzerReferenceInformationProvider(), new AnalyzerRunner(), new SolutionCodeFixApplier()),
         }.ToImmutableArray();
 
         public static async Task<WorkspaceFormatResult> FormatWorkspaceAsync(

--- a/src/FormattedFile.cs
+++ b/src/FormattedFile.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Tools
 {

--- a/src/Formatters/CharsetFormatter.cs
+++ b/src/Formatters/CharsetFormatter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Diagnostics.CodeAnalysis;
 using System.IO;

--- a/src/Formatters/EndOfLineFormatter.cs
+++ b/src/Formatters/EndOfLineFormatter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Formatters/FinalNewlineFormatter.cs
+++ b/src/Formatters/FinalNewlineFormatter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
 using System.Linq;

--- a/src/Logging/SimpleConsoleLogger.cs
+++ b/src/Logging/SimpleConsoleLogger.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Tools.Logging
             return NullScope.Instance;
         }
 
-        void LogToTerminal(string message, LogLevel logLevel)
+        private void LogToTerminal(string message, LogLevel logLevel)
         {
             var messageColor = LogLevelColorMap[logLevel];
             _terminal.ForegroundColor = messageColor;
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Tools.Logging
             _terminal.ResetColor();
         }
 
-        void LogToConsole(string message)
+        private void LogToConsole(string message)
         {
             _console.Out.Write($"  {message}{Environment.NewLine}");
         }

--- a/src/MSBuild/LooseVersionAssemblyLoader.cs
+++ b/src/MSBuild/LooseVersionAssemblyLoader.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -264,4 +264,7 @@
   <data name="Unable_to_fix_0_Code_fix_1_doesnt_support_Fix_All_in_Solution" xml:space="preserve">
     <value>Unable to fix {0}. Code fix {1} doesn't support Fix All in Solution.</value>
   </data>
+  <data name="Unable_to_fix_0_No_associated_code_fix_found" xml:space="preserve">
+    <value>Unable to fix {0}. No associated code fix found.</value>
+  </data>
 </root>

--- a/src/dotnet-format.csproj
+++ b/src/dotnet-format.csproj
@@ -13,6 +13,9 @@
     <NoWarn>$(NoWarn);8002</NoWarn>
     <Description>Command line tool for formatting C# and Visual Basic code files based on .editorconfig settings.</Description>
 
+    <!-- Copy nuget assemblies to build directory. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+
     <!-- Always run on the latest runtime installed. -->
     <RollForward>LatestMajor</RollForward>
 

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -212,6 +212,11 @@
         <target state="new">Unable to fix {0}. Code fix {1} doesn't support Fix All in Solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unable_to_fix_0_No_associated_code_fix_found">
+        <source>Unable to fix {0}. No associated code fix found.</source>
+        <target state="new">Unable to fix {0}. No associated code fix found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -212,6 +212,11 @@
         <target state="new">Unable to fix {0}. Code fix {1} doesn't support Fix All in Solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unable_to_fix_0_No_associated_code_fix_found">
+        <source>Unable to fix {0}. No associated code fix found.</source>
+        <target state="new">Unable to fix {0}. No associated code fix found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -212,6 +212,11 @@
         <target state="new">Unable to fix {0}. Code fix {1} doesn't support Fix All in Solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unable_to_fix_0_No_associated_code_fix_found">
+        <source>Unable to fix {0}. No associated code fix found.</source>
+        <target state="new">Unable to fix {0}. No associated code fix found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -212,6 +212,11 @@
         <target state="new">Unable to fix {0}. Code fix {1} doesn't support Fix All in Solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unable_to_fix_0_No_associated_code_fix_found">
+        <source>Unable to fix {0}. No associated code fix found.</source>
+        <target state="new">Unable to fix {0}. No associated code fix found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -212,6 +212,11 @@
         <target state="new">Unable to fix {0}. Code fix {1} doesn't support Fix All in Solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unable_to_fix_0_No_associated_code_fix_found">
+        <source>Unable to fix {0}. No associated code fix found.</source>
+        <target state="new">Unable to fix {0}. No associated code fix found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -212,6 +212,11 @@
         <target state="new">Unable to fix {0}. Code fix {1} doesn't support Fix All in Solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unable_to_fix_0_No_associated_code_fix_found">
+        <source>Unable to fix {0}. No associated code fix found.</source>
+        <target state="new">Unable to fix {0}. No associated code fix found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -212,6 +212,11 @@
         <target state="new">Unable to fix {0}. Code fix {1} doesn't support Fix All in Solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unable_to_fix_0_No_associated_code_fix_found">
+        <source>Unable to fix {0}. No associated code fix found.</source>
+        <target state="new">Unable to fix {0}. No associated code fix found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -212,6 +212,11 @@
         <target state="new">Unable to fix {0}. Code fix {1} doesn't support Fix All in Solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unable_to_fix_0_No_associated_code_fix_found">
+        <source>Unable to fix {0}. No associated code fix found.</source>
+        <target state="new">Unable to fix {0}. No associated code fix found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -212,6 +212,11 @@
         <target state="new">Unable to fix {0}. Code fix {1} doesn't support Fix All in Solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unable_to_fix_0_No_associated_code_fix_found">
+        <source>Unable to fix {0}. No associated code fix found.</source>
+        <target state="new">Unable to fix {0}. No associated code fix found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -212,6 +212,11 @@
         <target state="new">Unable to fix {0}. Code fix {1} doesn't support Fix All in Solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unable_to_fix_0_No_associated_code_fix_found">
+        <source>Unable to fix {0}. No associated code fix found.</source>
+        <target state="new">Unable to fix {0}. No associated code fix found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -212,6 +212,11 @@
         <target state="new">Unable to fix {0}. Code fix {1} doesn't support Fix All in Solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unable_to_fix_0_No_associated_code_fix_found">
+        <source>Unable to fix {0}. No associated code fix found.</source>
+        <target state="new">Unable to fix {0}. No associated code fix found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -212,6 +212,11 @@
         <target state="new">Unable to fix {0}. Code fix {1} doesn't support Fix All in Solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unable_to_fix_0_No_associated_code_fix_found">
+        <source>Unable to fix {0}. No associated code fix found.</source>
+        <target state="new">Unable to fix {0}. No associated code fix found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -212,6 +212,11 @@
         <target state="new">Unable to fix {0}. Code fix {1} doesn't support Fix All in Solution.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Unable_to_fix_0_No_associated_code_fix_found">
+        <source>Unable to fix {0}. No associated code fix found.</source>
+        <target state="new">Unable to fix {0}. No associated code fix found.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer">
         <source>Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</source>
         <target state="new">Unable to locate MSBuild. Ensure the .NET SDK was installed with the official installer.</target>

--- a/tests/Analyzers/AnalyzerAssemblyGenerator.cs
+++ b/tests/Analyzers/AnalyzerAssemblyGenerator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/tests/Analyzers/FilterDiagnosticsTests.cs
+++ b/tests/Analyzers/FilterDiagnosticsTests.cs
@@ -62,8 +62,8 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
                     GenerateCodeFix("CodeFixProvider1", "DiagnosticAnalyzerId"))
             };
 
-            var analyzersAndFixers = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
-            return ImmutableArray.Create(analyzersAndFixers[0].Analyzer);
+            var (analyzers, _) = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
+            return analyzers;
         }
 
         private IEnumerable<Project> GetProjects()

--- a/tests/Analyzers/FilterDiagnosticsTests.cs
+++ b/tests/Analyzers/FilterDiagnosticsTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
             var allAnalyzers = await GetAnalyzersAsync();
             var formattablePaths = ImmutableHashSet.Create(projects.First().Documents.First().FilePath);
             var minimumSeverity = DiagnosticSeverity.Warning;
-            var result = await AnalyzerFinderHelpers.FilterBySeverityAsync(projects,
+            var result = await AnalyzerFormatter.FilterBySeverityAsync(projects,
                                                                            allAnalyzers,
                                                                            formattablePaths,
                                                                            minimumSeverity,
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
             var allAnalyzers = await GetAnalyzersAsync();
             var formattablePaths = ImmutableHashSet.Create(projects.First().Documents.First().FilePath);
             var minimumSeverity = DiagnosticSeverity.Error;
-            var result = await AnalyzerFinderHelpers.FilterBySeverityAsync(projects,
+            var result = await AnalyzerFormatter.FilterBySeverityAsync(projects,
                                                                            allAnalyzers,
                                                                            formattablePaths,
                                                                            minimumSeverity,

--- a/tests/Analyzers/FilterDiagnosticsTests.cs
+++ b/tests/Analyzers/FilterDiagnosticsTests.cs
@@ -30,11 +30,12 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
             var allAnalyzers = await GetAnalyzersAsync();
             var formattablePaths = ImmutableHashSet.Create(projects.First().Documents.First().FilePath);
             var minimumSeverity = DiagnosticSeverity.Warning;
-            var result = await AnalyzerFormatter.FilterBySeverityAsync(projects,
-                                                                           allAnalyzers,
-                                                                           formattablePaths,
-                                                                           minimumSeverity,
-                                                                           CancellationToken.None);
+            var result = await AnalyzerFormatter.FilterBySeverityAsync(
+                projects,
+                allAnalyzers,
+                formattablePaths,
+                minimumSeverity,
+                CancellationToken.None);
             var (_, analyzers) = Assert.Single(result);
             Assert.Single(analyzers);
         }
@@ -46,11 +47,12 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
             var allAnalyzers = await GetAnalyzersAsync();
             var formattablePaths = ImmutableHashSet.Create(projects.First().Documents.First().FilePath);
             var minimumSeverity = DiagnosticSeverity.Error;
-            var result = await AnalyzerFormatter.FilterBySeverityAsync(projects,
-                                                                           allAnalyzers,
-                                                                           formattablePaths,
-                                                                           minimumSeverity,
-                                                                           CancellationToken.None);
+            var result = await AnalyzerFormatter.FilterBySeverityAsync(
+                projects,
+                allAnalyzers,
+                formattablePaths,
+                minimumSeverity,
+                CancellationToken.None);
             var (_, analyzers) = Assert.Single(result);
             Assert.Empty(analyzers);
         }

--- a/tests/Analyzers/FilterDiagnosticsTests.cs
+++ b/tests/Analyzers/FilterDiagnosticsTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;

--- a/tests/Analyzers/LoadAnalyzersAndFixersTests.cs
+++ b/tests/Analyzers/LoadAnalyzersAndFixersTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
 

--- a/tests/Analyzers/LoadAnalyzersAndFixersTests.cs
+++ b/tests/Analyzers/LoadAnalyzersAndFixersTests.cs
@@ -2,8 +2,6 @@
 
 using System.Threading.Tasks;
 
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Tools.Analyzers;
 
 using Xunit;
@@ -64,74 +62,6 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
             var (analyzers, fixers) = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
             Assert.Equal(2, analyzers.Length);
             Assert.Equal(2, fixers.Length);
-        }
-
-        [Fact]
-        public static async Task NonMatchingIdsAsync()
-        {
-            var assemblies = new[]
-            {
-                await GenerateAssemblyAsync(
-                    GenerateAnalyzerCode("DiagnosticAnalyzer1", "DiagnosticAnalyzerId"),
-                    GenerateCodeFix("CodeFixProvider1", "CodeFixProviderId"))
-            };
-
-            var (analyzers, fixers) = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
-            Assert.Empty(analyzers);
-            Assert.Empty(fixers);
-        }
-
-        [Fact]
-        public static async Task SomeMatchingIdsAsync()
-        {
-            var assemblies = new[]
-            {
-                await GenerateAssemblyAsync(
-                    GenerateAnalyzerCode("DiagnosticAnalyzer1", "DiagnosticAnalyzerId1"),
-                    GenerateAnalyzerCode("DiagnosticAnalyzer2", "DiagnosticAnalyzerId2"),
-                    GenerateCodeFix("CodeFixProvider1", "DiagnosticAnalyzerId1"),
-                    GenerateCodeFix("CodeFixProvider2", "CodeFixProviderId"))
-            };
-
-            var (analyzers, fixers) = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
-            var analyzer = Assert.Single(analyzers);
-            var fixer = Assert.Single(fixers);
-            var analyzerDiagnosticDescriptor = Assert.Single(analyzer.SupportedDiagnostics);
-            var fixerDiagnosticId = Assert.Single(fixer.FixableDiagnosticIds);
-            Assert.Equal(analyzerDiagnosticDescriptor.Id, fixerDiagnosticId);
-        }
-
-        [Fact]
-        public static async Task SingleIdMapstoMultipleFixersAsync()
-        {
-            var assemblies = new[]
-            {
-                await GenerateAssemblyAsync(
-                    GenerateAnalyzerCode("DiagnosticAnalyzer1", "DiagnosticAnalyzerId1"),
-                    GenerateAnalyzerCode("DiagnosticAnalyzer2", "DiagnosticAnalyzerId1"),
-                    GenerateCodeFix("CodeFixProvider1", "DiagnosticAnalyzerId1"),
-                    GenerateCodeFix("CodeFixProvider2", "CodeFixProviderId"))
-            };
-
-            var (analyzers, fixers) = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
-            Assert.Equal(2, analyzers.Length);
-            Assert.Equal(2, fixers.Length);
-        }
-
-        [Fact]
-        public static async Task MultipleIdsMaptoSingleFixerAsync()
-        {
-            var assemblies = new[]
-            {
-                await GenerateAssemblyAsync(
-                    GenerateAnalyzerCode("DiagnosticAnalyzer1", "DiagnosticAnalyzerId1"),
-                    GenerateAnalyzerCode("DiagnosticAnalyzer2", "DiagnosticAnalyzerId1"),
-                    GenerateCodeFix("CodeFixProvider1", "DiagnosticAnalyzerId1"))
-            };
-
-            var (analyzers, fixers) = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
-            Assert.Equal(2, analyzers.Length);
-            Assert.Single(fixers);
         }
     }
 }

--- a/tests/Analyzers/LoadAnalyzersAndFixersTests.cs
+++ b/tests/Analyzers/LoadAnalyzersAndFixersTests.cs
@@ -24,8 +24,9 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
                     GenerateCodeFix("CodeFixProvider1", "DiagnosticAnalyzerId"))
             };
 
-            var analyzersAndFixers = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
-            var (analyzer, fixer) = Assert.Single(analyzersAndFixers);
+            var (analyzers, fixers) = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
+            var analyzer = Assert.Single(analyzers);
+            var fixer = Assert.Single(fixers);
             var analyzerDiagnosticDescriptor = Assert.Single(analyzer.SupportedDiagnostics);
             var fixerDiagnosticId = Assert.Single(fixer.FixableDiagnosticIds);
             Assert.Equal(analyzerDiagnosticDescriptor.Id, fixerDiagnosticId);
@@ -43,9 +44,9 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
                     GenerateCodeFix("CodeFixProvider2", "DiagnosticAnalyzerId2"))
             };
 
-            var analyzersAndFixers = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
-            Assert.Equal(2, analyzersAndFixers.Length);
-            Assert.Collection(analyzersAndFixers, VerifyAnalyzerCodeFixTuple, VerifyAnalyzerCodeFixTuple);
+            var (analyzers, fixers) = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
+            Assert.Equal(2, analyzers.Length);
+            Assert.Equal(2, fixers.Length);
         }
 
         [Fact]
@@ -60,9 +61,9 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
                     GenerateAnalyzerCode("DiagnosticAnalyzer2", "DiagnosticAnalyzerId2"),
                     GenerateCodeFix("CodeFixProvider2", "DiagnosticAnalyzerId2")),
             };
-            var analyzersAndFixers = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
-            Assert.Equal(2, analyzersAndFixers.Length);
-            Assert.Collection(analyzersAndFixers, VerifyAnalyzerCodeFixTuple, VerifyAnalyzerCodeFixTuple);
+            var (analyzers, fixers) = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
+            Assert.Equal(2, analyzers.Length);
+            Assert.Equal(2, fixers.Length);
         }
 
         [Fact]
@@ -75,8 +76,9 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
                     GenerateCodeFix("CodeFixProvider1", "CodeFixProviderId"))
             };
 
-            var analyzersAndFixers = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
-            Assert.Empty(analyzersAndFixers);
+            var (analyzers, fixers) = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
+            Assert.Empty(analyzers);
+            Assert.Empty(fixers);
         }
 
         [Fact]
@@ -91,8 +93,9 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
                     GenerateCodeFix("CodeFixProvider2", "CodeFixProviderId"))
             };
 
-            var analyzersAndFixers = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
-            var (analyzer, fixer) = Assert.Single(analyzersAndFixers);
+            var (analyzers, fixers) = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
+            var analyzer = Assert.Single(analyzers);
+            var fixer = Assert.Single(fixers);
             var analyzerDiagnosticDescriptor = Assert.Single(analyzer.SupportedDiagnostics);
             var fixerDiagnosticId = Assert.Single(fixer.FixableDiagnosticIds);
             Assert.Equal(analyzerDiagnosticDescriptor.Id, fixerDiagnosticId);
@@ -110,9 +113,9 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
                     GenerateCodeFix("CodeFixProvider2", "CodeFixProviderId"))
             };
 
-            var analyzersAndFixers = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
-            Assert.Equal(2, analyzersAndFixers.Length);
-            Assert.Collection(analyzersAndFixers, VerifyAnalyzerCodeFixTuple, VerifyAnalyzerCodeFixTuple);
+            var (analyzers, fixers) = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
+            Assert.Equal(2, analyzers.Length);
+            Assert.Equal(2, fixers.Length);
         }
 
         [Fact]
@@ -126,16 +129,9 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
                     GenerateCodeFix("CodeFixProvider1", "DiagnosticAnalyzerId1"))
             };
 
-            var analyzersAndFixers = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
-            Assert.Equal(2, analyzersAndFixers.Length);
-            Assert.Collection(analyzersAndFixers, VerifyAnalyzerCodeFixTuple, VerifyAnalyzerCodeFixTuple);
-        }
-
-        private static void VerifyAnalyzerCodeFixTuple((DiagnosticAnalyzer Analyzer, CodeFixProvider Fixer) tuple)
-        {
-            var analyzerDiagnosticDescriptor = Assert.Single(tuple.Analyzer.SupportedDiagnostics);
-            var fixerDiagnosticId = Assert.Single(tuple.Fixer.FixableDiagnosticIds);
-            Assert.Equal(analyzerDiagnosticDescriptor.Id, fixerDiagnosticId);
+            var (analyzers, fixers) = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
+            Assert.Equal(2, analyzers.Length);
+            Assert.Equal(1, fixers.Length);
         }
     }
 }

--- a/tests/Analyzers/LoadAnalyzersAndFixersTests.cs
+++ b/tests/Analyzers/LoadAnalyzersAndFixersTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests.Analyzers
 
             var (analyzers, fixers) = AnalyzerFinderHelpers.LoadAnalyzersAndFixers(assemblies);
             Assert.Equal(2, analyzers.Length);
-            Assert.Equal(1, fixers.Length);
+            Assert.Single(fixers);
         }
     }
 }

--- a/tests/Extensions/ExportProviderExtensions.cs
+++ b/tests/Extensions/ExportProviderExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/tests/Formatters/AbstractFormatterTests.cs
+++ b/tests/Formatters/AbstractFormatterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/tests/Formatters/CSharpFormatterTests.cs
+++ b/tests/Formatters/CSharpFormatterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CSharp;
 

--- a/tests/Formatters/CharsetFormatterTests.cs
+++ b/tests/Formatters/CharsetFormatterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Text;

--- a/tests/Formatters/EndOfLineFormatterTests.cs
+++ b/tests/Formatters/EndOfLineFormatterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/tests/Formatters/FinalNewlineFormatterTests.cs
+++ b/tests/Formatters/FinalNewlineFormatterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/tests/Formatters/FormattedFilesTests.cs
+++ b/tests/Formatters/FormattedFilesTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/tests/Formatters/ImportsFormatterTests.cs
+++ b/tests/Formatters/ImportsFormatterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/tests/Utilities/XmlReferenceResolver.cs
+++ b/tests/Utilities/XmlReferenceResolver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
 using System.IO;


### PR DESCRIPTION
This builds on the work and refactoring done in https://github.com/dotnet/format/pull/720