### PR TITLE
Remove aliases for the fix style and fix analyzers options

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Arguments:
 
 Options:
   --folder, -f                        Whether to treat the `<workspace>` argument as a simple folder of files.
-  --fix-style, -fs <severity>         Run code style analyzers and apply fixes.
-  --fix-analyzers, -fa <severity>     Run 3rd party analyzers and apply fixes.
+  --fix-style <severity>              Run code style analyzers and apply fixes.
+  --fix-analyzers <severity>          Run 3rd party analyzers and apply fixes.
   --include <include>                 A list of relative file or folder paths to include in formatting. All files are formatted if empty.
   --exclude <exclude>                 A list of relative file or folder paths to exclude from formatting.
   --check                             Formats files without saving changes to disk. Terminates with a non-zero exit code if any files were formatted.

--- a/src/FormatCommand.cs
+++ b/src/FormatCommand.cs
@@ -22,11 +22,11 @@ namespace Microsoft.CodeAnalysis.Tools
                     Description = Resources.A_path_to_a_solution_file_a_project_file_or_a_folder_containing_a_solution_or_project_file_If_a_path_is_not_specified_then_the_current_directory_is_used
                 }.LegalFilePathsOnly(),
                 new Option(new[] { "--folder", "-f" }, Resources.Whether_to_treat_the_workspace_argument_as_a_simple_folder_of_files),
-                new Option(new[] { "--fix-style", "-fs" }, Resources.Run_code_style_analyzers_and_apply_fixes)
+                new Option(new[] { "--fix-style" }, Resources.Run_code_style_analyzers_and_apply_fixes)
                 {
                     Argument = new Argument<string?>("severity") { Arity = ArgumentArity.ZeroOrOne }.FromAmong(SeverityLevels)
                 },
-                new Option(new[] { "--fix-analyzers", "-fa" }, Resources.Run_3rd_party_analyzers_and_apply_fixes)
+                new Option(new[] { "--fix-analyzers" }, Resources.Run_3rd_party_analyzers_and_apply_fixes)
                 {
                     Argument = new Argument<string?>("severity") { Arity = ArgumentArity.ZeroOrOne }.FromAmong(SeverityLevels)
                 },


### PR DESCRIPTION
Based on https://github.com/dotnet/format/issues/744#issuecomment-671962627 as well as the difficulty we had when the `-f` option accepted an argument, we are not using aliases correctly. They are intended to be a single letter. Let's remove these until we have a better plan for them.