### PR TITLE
Improve folder performance

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -10,23 +10,23 @@
     <MicrosoftBuildVersion>15.3.409</MicrosoftBuildVersion>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
     <MicrosoftNETCoreCompilersPackageVersion>3.8.0-2.20413.3</MicrosoftNETCoreCompilersPackageVersion>
-    <MicrosoftExtensionsVersion>3.1.1</MicrosoftExtensionsVersion>
+    <MicrosoftExtensionsVersion>5.0.0-preview.7.20364.11</MicrosoftExtensionsVersion>
   </PropertyGroup>
   <!--
     Other Dependency versions
   -->
   <PropertyGroup>
-    <SystemCommandLineVersion>2.0.0-beta1.20303.1</SystemCommandLineVersion>
-    <SystemCommandLineRenderingVersion>0.3.0-alpha.20303.1</SystemCommandLineRenderingVersion>
+    <SystemCommandLineVersion>2.0.0-beta1.20371.2</SystemCommandLineVersion>
+    <SystemCommandLineRenderingVersion>0.3.0-alpha.20371.2</SystemCommandLineRenderingVersion>
     <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildVersion)</MicrosoftBuildFrameworkVersion>
     <MicrosoftBuildLocatorVersion>1.2.6</MicrosoftBuildLocatorVersion>
-    <MicrosoftCodeAnalysisAnalyzerTestingVersion>1.0.1-beta1.20114.4</MicrosoftCodeAnalysisAnalyzerTestingVersion>
+    <MicrosoftCodeAnalysisAnalyzerTestingVersion>1.0.1-beta1.20413.3</MicrosoftCodeAnalysisAnalyzerTestingVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>$(MicrosoftExtensionsVersion)</MicrosoftExtensionsDependencyInjectionVersion>
     <MicrosoftExtensionsFileSystemGlobbingVersion>$(MicrosoftExtensionsVersion)</MicrosoftExtensionsFileSystemGlobbingVersion>
     <MicrosoftExtensionsLoggingVersion>$(MicrosoftExtensionsVersion)</MicrosoftExtensionsLoggingVersion>
-    <MicrosoftCodeAnalysisAnalyzersVersion>3.0.0</MicrosoftCodeAnalysisAnalyzersVersion>
+    <MicrosoftCodeAnalysisAnalyzersVersion>3.3.0</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCodeAnalysisVersion>$(MicrosoftNETCoreCompilersPackageVersion)</MicrosoftCodeAnalysisVersion>
-    <SystemTextJsonVersion>4.7.0</SystemTextJsonVersion>
+    <SystemTextJsonVersion>$(MicrosoftExtensionsVersion)</SystemTextJsonVersion>
     <!--
       Workaround for the inability to load the NugetSdkResolver from the .NET 5 SDK
       https://github.com/microsoft/MSBuildLocator/issues/88

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -106,28 +106,31 @@ namespace Microsoft.CodeAnalysis.Tools
                     }
                 }
 
-                var runtimeVersion = GetRuntimeVersion();
-
-                logger.LogDebug(Resources.The_dotnet_runtime_version_is_0, runtimeVersion);
-
-                // Load MSBuild
-                Environment.CurrentDirectory = workspaceDirectory;
-
-                if (!TryGetDotNetCliVersion(out var dotnetVersion))
+                if (workspaceType != WorkspaceType.Folder)
                 {
-                    logger.LogError(Resources.Unable_to_locate_dotnet_CLI_Ensure_that_it_is_on_the_PATH);
-                    return UnableToLocateDotNetCliExitCode;
+                    var runtimeVersion = GetRuntimeVersion();
+
+                    logger.LogDebug(Resources.The_dotnet_runtime_version_is_0, runtimeVersion);
+
+                    // Load MSBuild
+                    Environment.CurrentDirectory = workspaceDirectory;
+
+                    if (!TryGetDotNetCliVersion(out var dotnetVersion))
+                    {
+                        logger.LogError(Resources.Unable_to_locate_dotnet_CLI_Ensure_that_it_is_on_the_PATH);
+                        return UnableToLocateDotNetCliExitCode;
+                    }
+
+                    logger.LogTrace(Resources.The_dotnet_CLI_version_is_0, dotnetVersion);
+
+                    if (!TryLoadMSBuild(out var msBuildPath))
+                    {
+                        logger.LogError(Resources.Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer);
+                        return UnableToLocateMSBuildExitCode;
+                    }
+
+                    logger.LogTrace(Resources.Using_msbuildexe_located_in_0, msBuildPath);
                 }
-
-                logger.LogTrace(Resources.The_dotnet_CLI_version_is_0, dotnetVersion);
-
-                if (!TryLoadMSBuild(out var msBuildPath))
-                {
-                    logger.LogError(Resources.Unable_to_locate_MSBuild_Ensure_the_NET_SDK_was_installed_with_the_official_installer);
-                    return UnableToLocateMSBuildExitCode;
-                }
-
-                logger.LogTrace(Resources.Using_msbuildexe_located_in_0, msBuildPath);
 
                 var fileMatcher = SourceFileMatcher.CreateMatcher(include, exclude);
 
@@ -225,7 +228,7 @@ namespace Microsoft.CodeAnalysis.Tools
             var serviceProvider = serviceCollection.BuildServiceProvider();
             var logger = serviceProvider.GetService<ILogger<Program>>();
 
-            return logger;
+            return logger!;
         }
 
         private static bool TryGetDotNetCliVersion([NotNullWhen(returnValue: true)] out string? dotnetVersion)

--- a/src/Workspaces/FolderWorkspace.cs
+++ b/src/Workspaces/FolderWorkspace.cs
@@ -3,8 +3,6 @@
 using System;
 using System.IO;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
@@ -23,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Tools.Workspaces
 
         public static FolderWorkspace Create()
         {
-            return Create(MSBuildMefHostServices.DefaultServices);
+            return Create(MefHostServices.DefaultHost);
         }
 
         public static FolderWorkspace Create(HostServices hostServices)
@@ -31,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Tools.Workspaces
             return new FolderWorkspace(hostServices);
         }
 
-        public async Task<Solution> OpenFolder(string folderPath, Matcher fileMatcher, CancellationToken cancellationToken)
+        public Solution OpenFolder(string folderPath, Matcher fileMatcher)
         {
             if (string.IsNullOrEmpty(folderPath) || !Directory.Exists(folderPath))
             {
@@ -40,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Tools.Workspaces
 
             ClearSolution();
 
-            var solutionInfo = await FolderSolutionLoader.LoadSolutionInfoAsync(folderPath, fileMatcher, cancellationToken).ConfigureAwait(false);
+            var solutionInfo = FolderSolutionLoader.LoadSolutionInfo(folderPath, fileMatcher);
 
             OnSolutionAdded(solutionInfo);
 

--- a/src/Workspaces/FolderWorkspace_ProjectLoader.cs
+++ b/src/Workspaces/FolderWorkspace_ProjectLoader.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Tools.Utilities;
-using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace Microsoft.CodeAnalysis.Tools.Workspaces
 {
@@ -19,23 +16,30 @@ namespace Microsoft.CodeAnalysis.Tools.Workspaces
             public abstract string FileExtension { get; }
             public virtual string ProjectName => $"{Language}{FileExtension}proj";
 
-            public virtual async Task<ProjectInfo?> LoadProjectInfoAsync(string folderPath, Matcher fileMatcher, CancellationToken cancellationToken)
+            public virtual ProjectInfo? LoadProjectInfo(string folderPath, ImmutableArray<string> filePaths, ImmutableArray<string> editorConfigPaths)
             {
                 var projectId = ProjectId.CreateNewId(debugName: folderPath);
+                var projectFilePaths = filePaths.Where(path => path.EndsWith(FileExtension, StringComparison.InvariantCulture));
 
-                var documents = await LoadDocumentInfosAsync(projectId, folderPath, FileExtension, fileMatcher).ConfigureAwait(false);
+                var documents = projectFilePaths.Select(
+                    path => DocumentInfo.Create(
+                        DocumentId.CreateNewId(projectId, debugName: path),
+                        name: Path.GetFileName(path),
+                        loader: new FileTextLoader(path, DefaultEncoding),
+                        filePath: path))
+                    .ToImmutableArray();
+
                 if (documents.IsDefaultOrEmpty)
                 {
                     return null;
                 }
 
-                var editorConfigDocuments = EditorConfigFinder.GetEditorConfigPaths(folderPath)
-                    .Select(path =>
-                        DocumentInfo.Create(
-                            DocumentId.CreateNewId(projectId),
-                            name: path,
-                            loader: new FileTextLoader(path, Encoding.UTF8),
-                            filePath: path))
+                var editorConfigDocuments = editorConfigPaths.Select(
+                    path => DocumentInfo.Create(
+                        DocumentId.CreateNewId(projectId),
+                        name: path,
+                        loader: new FileTextLoader(path, Encoding.UTF8),
+                        filePath: path))
                     .ToImmutableArray();
 
                 return ProjectInfo.Create(
@@ -47,35 +51,6 @@ namespace Microsoft.CodeAnalysis.Tools.Workspaces
                     filePath: folderPath,
                     documents: documents)
                     .WithAnalyzerConfigDocuments(editorConfigDocuments);
-            }
-
-            private static Task<ImmutableArray<DocumentInfo>> LoadDocumentInfosAsync(ProjectId projectId, string folderPath, string fileExtension, Matcher fileMatcher)
-            {
-                return Task.Run(() =>
-                {
-                    var filePaths = Directory.GetFiles(folderPath, $"*{fileExtension}", SearchOption.AllDirectories)
-                        .Where(filePath => fileMatcher.Match(filePath).HasMatches).ToArray();
-
-                    if (filePaths.Length == 0)
-                    {
-                        return ImmutableArray<DocumentInfo>.Empty;
-                    }
-
-                    var documentInfos = ImmutableArray.CreateBuilder<DocumentInfo>(filePaths.Length);
-
-                    foreach (var filePath in filePaths)
-                    {
-                        var documentInfo = DocumentInfo.Create(
-                            DocumentId.CreateNewId(projectId, debugName: filePath),
-                            name: Path.GetFileName(filePath),
-                            loader: new FileTextLoader(filePath, DefaultEncoding),
-                            filePath: filePath);
-
-                        documentInfos.Add(documentInfo);
-                    }
-
-                    return documentInfos.ToImmutableArray();
-                });
             }
         }
     }

--- a/src/Workspaces/MSBuildWorkspaceLoader.cs
+++ b/src/Workspaces/MSBuildWorkspaceLoader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/Workspaces/MSBuildWorkspaceLoader.cs
+++ b/src/Workspaces/MSBuildWorkspaceLoader.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.MSBuild;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.CodeAnalysis.Tools.Workspaces
+{
+    internal static class MSBuildWorkspaceLoader
+    {
+        public static async Task<Workspace?> LoadAsync(
+            string solutionOrProjectPath,
+            WorkspaceType workspaceType,
+            bool createBinaryLog,
+            bool logWorkspaceWarnings,
+            ILogger logger,
+            CancellationToken cancellationToken)
+        {
+            var properties = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                // This property ensures that XAML files will be compiled in the current AppDomain
+                // rather than a separate one. Any tasks isolated in AppDomains or tasks that create
+                // AppDomains will likely not work due to https://github.com/Microsoft/MSBuildLocator/issues/16.
+                { "AlwaysCompileMarkupFilesInSeparateDomain", bool.FalseString },
+            };
+
+            var workspace = MSBuildWorkspace.Create(properties);
+
+            Build.Framework.ILogger? binlog = null;
+            if (createBinaryLog)
+            {
+                binlog = new Build.Logging.BinaryLogger()
+                {
+                    Parameters = Path.Combine(Environment.CurrentDirectory, "formatDiagnosticLog.binlog"),
+                    Verbosity = Build.Framework.LoggerVerbosity.Diagnostic,
+                };
+            }
+
+            if (workspaceType == WorkspaceType.Solution)
+            {
+                await workspace.OpenSolutionAsync(solutionOrProjectPath, msbuildLogger: binlog, cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                try
+                {
+                    await workspace.OpenProjectAsync(solutionOrProjectPath, msbuildLogger: binlog, cancellationToken: cancellationToken).ConfigureAwait(false);
+                }
+                catch (InvalidOperationException)
+                {
+                    logger.LogError(Resources.Could_not_format_0_Format_currently_supports_only_CSharp_and_Visual_Basic_projects, solutionOrProjectPath);
+                    workspace.Dispose();
+                    return null;
+                }
+            }
+
+            LogWorkspaceDiagnostics(logger, logWorkspaceWarnings, workspace.Diagnostics);
+
+            return workspace;
+
+            static void LogWorkspaceDiagnostics(ILogger logger, bool logWorkspaceWarnings, ImmutableList<WorkspaceDiagnostic> diagnostics)
+            {
+                if (!logWorkspaceWarnings)
+                {
+                    if (diagnostics.Count > 0)
+                    {
+                        logger.LogWarning(Resources.Warnings_were_encountered_while_loading_the_workspace_Set_the_verbosity_option_to_the_diagnostic_level_to_log_warnings);
+                    }
+
+                    return;
+                }
+
+                foreach (var diagnostic in diagnostics)
+                {
+                    if (diagnostic.Kind == WorkspaceDiagnosticKind.Failure)
+                    {
+                        logger.LogError(diagnostic.Message);
+                    }
+                    else
+                    {
+                        logger.LogWarning(diagnostic.Message);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Improve https://github.com/dotnet/format/issues/757. This PR does a few things. 

- Updates dependency versions 
- No longer take a hit for logging information about .NET Sdk or loading MSBuild if using the `--folder` option
- Use the FileGlobMatcher to determine the list of matched file paths when loading the folder workspace once. Project loaders will filter by extension.
- Only enumerate the potential .editorconfig file paths once for the FolderWorkspace and pass to the ProjectLoaders.