### PR TITLE
Improve folder workspace performance

### DIFF
--- a/perf/FormattedFiles.cs
+++ b/perf/FormattedFiles.cs
@@ -4,7 +4,6 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using Microsoft.CodeAnalysis.Tools.Utilities;
-using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools.Perf
@@ -17,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
         private const string UnformattedSolutionFilePath = "tests/projects/for_code_formatter/unformatted_solution/unformatted_solution.sln";
 
         private static EmptyLogger EmptyLogger => new EmptyLogger();
-        private static Matcher AllFileMatcher => SourceFileMatcher.CreateMatcher(Array.Empty<string>(), Array.Empty<string>());
+        private static SourceFileMatcher AllFileMatcher => SourceFileMatcher.CreateMatcher(Array.Empty<string>(), Array.Empty<string>());
 
         [IterationSetup]
         public void NoFilesFormattedSetup()

--- a/perf/NoFilesFormatted.cs
+++ b/perf/NoFilesFormatted.cs
@@ -4,7 +4,6 @@ using System;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
 using Microsoft.CodeAnalysis.Tools.Utilities;
-using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools.Perf
@@ -17,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
         private const string FormattedSolutionFilePath = "tests/projects/for_code_formatter/formatted_solution/formatted_solution.sln";
 
         private static EmptyLogger EmptyLogger => new EmptyLogger();
-        private static Matcher AllFileMatcher => SourceFileMatcher.CreateMatcher(Array.Empty<string>(), Array.Empty<string>());
+        private static SourceFileMatcher AllFileMatcher => SourceFileMatcher.CreateMatcher(Array.Empty<string>(), Array.Empty<string>());
 
         [IterationSetup]
         public void NoFilesFormattedSetup()

--- a/perf/RealWorldSolution.cs
+++ b/perf/RealWorldSolution.cs
@@ -7,7 +7,6 @@ using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 using Microsoft.CodeAnalysis.Tools.Utilities;
-using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools.Perf
@@ -19,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Tools.Perf
         private const string UnformattedSolutionFilePath = UnformattedFolderFilePath + "ProjectSystem.sln";
 
         private static EmptyLogger EmptyLogger => new EmptyLogger();
-        private static Matcher AllFileMatcher => SourceFileMatcher.CreateMatcher(Array.Empty<string>(), Array.Empty<string>());
+        private static SourceFileMatcher AllFileMatcher => SourceFileMatcher.CreateMatcher(Array.Empty<string>(), Array.Empty<string>());
 
         [IterationSetup]
         public void RealWorldSolutionIterationSetup()

--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Tools
             var workspaceStopwatch = Stopwatch.StartNew();
 
             using var workspace = formatOptions.WorkspaceType == WorkspaceType.Folder
-                ? OpenFolderWorkspaceAsync(formatOptions.WorkspaceFilePath, formatOptions.FileMatcher)
+                ? OpenFolderWorkspace(formatOptions.WorkspaceFilePath, formatOptions.FileMatcher)
                 : await OpenMSBuildWorkspaceAsync(formatOptions.WorkspaceFilePath, formatOptions.WorkspaceType, createBinaryLog, logWorkspaceWarnings, logger, cancellationToken).ConfigureAwait(false);
 
             if (workspace is null)
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Tools
             return new WorkspaceFormatResult(filesFormatted, fileCount, exitCode);
         }
 
-        private static Workspace OpenFolderWorkspaceAsync(string workspacePath, SourceFileMatcher fileMatcher)
+        private static Workspace OpenFolderWorkspace(string workspacePath, SourceFileMatcher fileMatcher)
         {
             var folderWorkspace = FolderWorkspace.Create();
             folderWorkspace.OpenFolder(workspacePath, fileMatcher);

--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -4,24 +4,20 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Tools.Analyzers;
 using Microsoft.CodeAnalysis.Tools.Formatters;
 using Microsoft.CodeAnalysis.Tools.Utilities;
 using Microsoft.CodeAnalysis.Tools.Workspaces;
-using Microsoft.Extensions.FileSystemGlobbing;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools
 {
     internal static class CodeFormatter
     {
-        private static readonly ImmutableArray<ICodeFormatter> s_codeFormatters = new ICodeFormatter[]
-        {
+        private static readonly ImmutableArray<ICodeFormatter> s_codeFormatters = ImmutableArray.Create<ICodeFormatter>(
             new WhitespaceFormatter(),
             new FinalNewlineFormatter(),
             new EndOfLineFormatter(),
@@ -29,8 +25,7 @@ namespace Microsoft.CodeAnalysis.Tools
             new OrganizeImportsFormatter(),
             new UnnecessaryImportsFormatter(),
             new AnalyzerFormatter(Resources.Code_Style, new CodeStyleInformationProvider(), new AnalyzerRunner(), new SolutionCodeFixApplier()),
-            new AnalyzerFormatter(Resources.Analyzer_Reference, new AnalyzerReferenceInformationProvider(), new AnalyzerRunner(), new SolutionCodeFixApplier()),
-        }.ToImmutableArray();
+            new AnalyzerFormatter(Resources.Analyzer_Reference, new AnalyzerReferenceInformationProvider(), new AnalyzerRunner(), new SolutionCodeFixApplier()));
 
         public static async Task<WorkspaceFormatResult> FormatWorkspaceAsync(
             FormatOptions formatOptions,
@@ -47,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Tools
             var workspaceStopwatch = Stopwatch.StartNew();
 
             using var workspace = formatOptions.WorkspaceType == WorkspaceType.Folder
-                ? await OpenFolderWorkspaceAsync(formatOptions.WorkspaceFilePath, formatOptions.FileMatcher, cancellationToken).ConfigureAwait(false)
+                ? OpenFolderWorkspaceAsync(formatOptions.WorkspaceFilePath, formatOptions.FileMatcher)
                 : await OpenMSBuildWorkspaceAsync(formatOptions.WorkspaceFilePath, formatOptions.WorkspaceType, createBinaryLog, logWorkspaceWarnings, logger, cancellationToken).ConfigureAwait(false);
 
             if (workspace is null)
@@ -56,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Tools
             }
 
             var loadWorkspaceMS = workspaceStopwatch.ElapsedMilliseconds;
-            logger.LogTrace(Resources.Complete_in_0_ms, workspaceStopwatch.ElapsedMilliseconds);
+            logger.LogTrace(Resources.Complete_in_0_ms, loadWorkspaceMS);
 
             var projectPath = formatOptions.WorkspaceType == WorkspaceType.Project ? formatOptions.WorkspaceFilePath : string.Empty;
             var solution = workspace.CurrentSolution;
@@ -64,14 +59,14 @@ namespace Microsoft.CodeAnalysis.Tools
             logger.LogTrace(Resources.Determining_formattable_files);
 
             var (fileCount, formatableFiles) = await DetermineFormattableFilesAsync(
-                solution, projectPath, formatOptions.FileMatcher, formatOptions.IncludeGeneratedFiles, logger, cancellationToken).ConfigureAwait(false);
+                solution, projectPath, formatOptions, logger, cancellationToken).ConfigureAwait(false);
 
             var determineFilesMS = workspaceStopwatch.ElapsedMilliseconds - loadWorkspaceMS;
             logger.LogTrace(Resources.Complete_in_0_ms, determineFilesMS);
 
             logger.LogTrace(Resources.Running_formatters);
 
-            var formattedFiles = new List<FormattedFile>();
+            var formattedFiles = new List<FormattedFile>(fileCount);
             var formattedSolution = await RunCodeFormattersAsync(
                 solution, formatableFiles, formatOptions, logger, formattedFiles, cancellationToken).ConfigureAwait(false);
 
@@ -106,22 +101,7 @@ namespace Microsoft.CodeAnalysis.Tools
 
             if (exitCode == 0 && !string.IsNullOrWhiteSpace(formatOptions.ReportPath))
             {
-                var reportFilePath = GetReportFilePath(formatOptions.ReportPath!); // IsNullOrEmpty is not annotated on .NET Core 2.1
-                var reportFolderPath = Path.GetDirectoryName(reportFilePath);
-
-                if (!Directory.Exists(reportFolderPath))
-                {
-                    Directory.CreateDirectory(reportFolderPath);
-                }
-
-                logger.LogInformation(Resources.Writing_formatting_report_to_0, reportFilePath);
-                var seralizerOptions = new JsonSerializerOptions
-                {
-                    WriteIndented = true
-                };
-                var formattedFilesJson = JsonSerializer.Serialize(formattedFiles, seralizerOptions);
-
-                File.WriteAllText(reportFilePath, formattedFilesJson);
+                ReportWriter.Write(formatOptions.ReportPath!, formattedFiles, logger);
             }
 
             logger.LogDebug(Resources.Formatted_0_of_1_files, filesFormatted, fileCount);
@@ -131,31 +111,11 @@ namespace Microsoft.CodeAnalysis.Tools
             return new WorkspaceFormatResult(filesFormatted, fileCount, exitCode);
         }
 
-        private static string GetReportFilePath(string reportPath)
+        private static Workspace OpenFolderWorkspaceAsync(string workspacePath, SourceFileMatcher fileMatcher)
         {
-            var defaultReportName = "format-report.json";
-            if (reportPath.EndsWith(".json"))
-            {
-                return reportPath;
-            }
-            else if (reportPath == ".")
-            {
-                return Path.Combine(Environment.CurrentDirectory, defaultReportName);
-            }
-            else
-            {
-                return Path.Combine(reportPath, defaultReportName);
-            }
-        }
-
-        private static Task<Workspace> OpenFolderWorkspaceAsync(string workspacePath, Matcher fileMatcher, CancellationToken cancellationToken)
-        {
-            return Task.Run<Workspace>(() =>
-            {
-                var folderWorkspace = FolderWorkspace.Create();
-                folderWorkspace.OpenFolder(workspacePath, fileMatcher);
-                return folderWorkspace;
-            }, cancellationToken);
+            var folderWorkspace = FolderWorkspace.Create();
+            folderWorkspace.OpenFolder(workspacePath, fileMatcher);
+            return folderWorkspace;
         }
 
         private static Task<Workspace?> OpenMSBuildWorkspaceAsync(
@@ -179,9 +139,9 @@ namespace Microsoft.CodeAnalysis.Tools
         {
             var formattedSolution = solution;
 
-            foreach (var codeFormatter in s_codeFormatters)
+            for (var index = 0; index < s_codeFormatters.Length; index++)
             {
-                formattedSolution = await codeFormatter.FormatAsync(formattedSolution, formattableDocuments, formatOptions, logger, formattedFiles, cancellationToken).ConfigureAwait(false);
+                formattedSolution = await s_codeFormatters[index].FormatAsync(formattedSolution, formattableDocuments, formatOptions, logger, formattedFiles, cancellationToken).ConfigureAwait(false);
             }
 
             return formattedSolution;
@@ -190,8 +150,7 @@ namespace Microsoft.CodeAnalysis.Tools
         internal static async Task<(int, ImmutableArray<DocumentId>)> DetermineFormattableFilesAsync(
             Solution solution,
             string projectPath,
-            Matcher fileMatcher,
-            bool includeGeneratedFiles,
+            FormatOptions formatOptions,
             ILogger logger,
             CancellationToken cancellationToken)
         {
@@ -237,8 +196,9 @@ namespace Microsoft.CodeAnalysis.Tools
 
                     addedFilePaths.Add(document.FilePath);
 
-                    if (!fileMatcher.Match(document.FilePath).HasMatches ||
-                        !document.SupportsSyntaxTree)
+                    var isFileIncluded = formatOptions.WorkspaceType == WorkspaceType.Folder ||
+                        formatOptions.FileMatcher.Match(document.FilePath).HasMatches;
+                    if (!isFileIncluded || !document.SupportsSyntaxTree)
                     {
                         continue;
                     }
@@ -249,7 +209,7 @@ namespace Microsoft.CodeAnalysis.Tools
                         throw new Exception($"Unable to get a syntax tree for '{document.Name}'");
                     }
 
-                    if (!includeGeneratedFiles &&
+                    if (!formatOptions.IncludeGeneratedFiles &&
                         await GeneratedCodeUtilities.IsGeneratedCodeAsync(syntaxTree, cancellationToken).ConfigureAwait(false))
                     {
                         continue;
@@ -277,8 +237,8 @@ namespace Microsoft.CodeAnalysis.Tools
             // If no files are covered by an editorconfig, then return them all. Otherwise only return
             // files that are covered by an editorconfig.
             return documentsCoveredByEditorConfig.Count == 0
-                ? (projectFileCount, documentsNotCoveredByEditorConfig.ToImmutableArray())
-                : (projectFileCount, documentsCoveredByEditorConfig.ToImmutableArray());
+                ? (projectFileCount, documentsNotCoveredByEditorConfig.ToImmutable())
+                : (projectFileCount, documentsCoveredByEditorConfig.ToImmutable());
         }
     }
 }

--- a/src/FormatOptions.cs
+++ b/src/FormatOptions.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
-using Microsoft.Extensions.FileSystemGlobbing;
+using Microsoft.CodeAnalysis.Tools.Utilities;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Tools
         public DiagnosticSeverity AnalyzerSeverity { get; }
         public bool SaveFormattedFiles { get; }
         public bool ChangesAreErrors { get; }
-        public Matcher FileMatcher { get; }
+        public SourceFileMatcher FileMatcher { get; }
         public string? ReportPath { get; }
         public bool IncludeGeneratedFiles { get; }
 
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Tools
             DiagnosticSeverity analyzerSeverity,
             bool saveFormattedFiles,
             bool changesAreErrors,
-            Matcher fileMatcher,
+            SourceFileMatcher fileMatcher,
             string? reportPath,
             bool includeGeneratedFiles)
         {
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Tools
             out DiagnosticSeverity analyzerSeverity,
             out bool saveFormattedFiles,
             out bool changesAreErrors,
-            out Matcher fileMatcher,
+            out SourceFileMatcher fileMatcher,
             out string? reportPath,
             out bool includeGeneratedFiles)
         {

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-
 using Microsoft.CodeAnalysis.Tools.Logging;
 using Microsoft.CodeAnalysis.Tools.MSBuild;
 using Microsoft.CodeAnalysis.Tools.Utilities;

--- a/src/ReportWriter.cs
+++ b/src/ReportWriter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
 using System.Collections.Generic;

--- a/src/ReportWriter.cs
+++ b/src/ReportWriter.cs
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.CodeAnalysis.Tools
+{
+    internal static class ReportWriter
+    {
+        public static void Write(string reportPath, IEnumerable<FormattedFile> formattedFiles, ILogger logger)
+        {
+            var reportFilePath = GetReportFilePath(reportPath);
+            var reportFolderPath = Path.GetDirectoryName(reportFilePath);
+
+            if (!Directory.Exists(reportFolderPath))
+            {
+                Directory.CreateDirectory(reportFolderPath);
+            }
+
+            logger.LogInformation(Resources.Writing_formatting_report_to_0, reportFilePath);
+
+            var seralizerOptions = new JsonSerializerOptions
+            {
+                WriteIndented = true
+            };
+            var formattedFilesJson = JsonSerializer.Serialize(formattedFiles, seralizerOptions);
+
+            File.WriteAllText(reportFilePath, formattedFilesJson);
+        }
+
+        private static string GetReportFilePath(string reportPath)
+        {
+            var defaultReportName = "format-report.json";
+            if (reportPath.EndsWith(".json"))
+            {
+                return reportPath;
+            }
+            else if (reportPath == ".")
+            {
+                return Path.Combine(Environment.CurrentDirectory, defaultReportName);
+            }
+            else
+            {
+                return Path.Combine(reportPath, defaultReportName);
+            }
+        }
+    }
+}

--- a/src/Utilities/SourceFileMatcher.cs
+++ b/src/Utilities/SourceFileMatcher.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace Microsoft.CodeAnalysis.Tools.Utilities

--- a/src/Utilities/SourceFileMatcher.cs
+++ b/src/Utilities/SourceFileMatcher.cs
@@ -2,21 +2,38 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace Microsoft.CodeAnalysis.Tools.Utilities
 {
-    internal static class SourceFileMatcher
+    internal sealed class SourceFileMatcher
     {
-        private static IEnumerable<string> AllFilesList => new[] { @"**/*.*" };
+        private static string[] AllFilesList => new[] { @"**/*.*" };
 
-        public static Matcher CreateMatcher(IEnumerable<string> include, IEnumerable<string> exclude)
+        public static SourceFileMatcher CreateMatcher(string[] include, string[] exclude)
+            => new SourceFileMatcher(include.Length > 0 ? include : AllFilesList, exclude);
+
+        private readonly Matcher _matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
+
+        public ImmutableArray<string> Include { get; }
+        public ImmutableArray<string> Exclude { get; }
+
+        private SourceFileMatcher(string[] include, string[] exclude)
         {
-            var fileMatcher = new Matcher(StringComparison.OrdinalIgnoreCase);
-            fileMatcher.AddIncludePatterns(include.Any() ? include : AllFilesList);
-            fileMatcher.AddExcludePatterns(exclude);
-            return fileMatcher;
+            Include = include.ToImmutableArray();
+            Exclude = exclude.ToImmutableArray();
+
+            _matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
+            _matcher.AddIncludePatterns(Include);
+            _matcher.AddExcludePatterns(Exclude);
         }
+
+        public PatternMatchingResult Match(string filePath)
+            => _matcher.Match(filePath);
+
+        public IEnumerable<string> GetResultsInFullPath(string directoryPath)
+            => _matcher.GetResultsInFullPath(directoryPath);
     }
 }

--- a/src/Workspaces/FolderWorkspace.cs
+++ b/src/Workspaces/FolderWorkspace.cs
@@ -6,7 +6,7 @@ using System.Text;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.Extensions.FileSystemGlobbing;
+using Microsoft.CodeAnalysis.Tools.Utilities;
 
 namespace Microsoft.CodeAnalysis.Tools.Workspaces
 {
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Tools.Workspaces
             return new FolderWorkspace(hostServices);
         }
 
-        public Solution OpenFolder(string folderPath, Matcher fileMatcher)
+        public Solution OpenFolder(string folderPath, SourceFileMatcher fileMatcher)
         {
             if (string.IsNullOrEmpty(folderPath) || !Directory.Exists(folderPath))
             {

--- a/src/Workspaces/FolderWorkspace_ProjectLoader.cs
+++ b/src/Workspaces/FolderWorkspace_ProjectLoader.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
-using System.Linq;
-using System.Text;
 
 namespace Microsoft.CodeAnalysis.Tools.Workspaces
 {
@@ -18,29 +16,21 @@ namespace Microsoft.CodeAnalysis.Tools.Workspaces
 
             public virtual ProjectInfo? LoadProjectInfo(string folderPath, ImmutableArray<string> filePaths, ImmutableArray<string> editorConfigPaths)
             {
-                var projectId = ProjectId.CreateNewId(debugName: folderPath);
-                var projectFilePaths = filePaths.Where(path => path.EndsWith(FileExtension, StringComparison.InvariantCulture));
+                var projectFilePaths = ImmutableArray.CreateBuilder<string>(filePaths.Length);
+                for (var index = 0; index < filePaths.Length; index++)
+                {
+                    if (filePaths[index].EndsWith(FileExtension, StringComparison.InvariantCulture))
+                    {
+                        projectFilePaths.Add(filePaths[index]);
+                    }
+                }
 
-                var documents = projectFilePaths.Select(
-                    path => DocumentInfo.Create(
-                        DocumentId.CreateNewId(projectId, debugName: path),
-                        name: Path.GetFileName(path),
-                        loader: new FileTextLoader(path, DefaultEncoding),
-                        filePath: path))
-                    .ToImmutableArray();
-
-                if (documents.IsDefaultOrEmpty)
+                if (projectFilePaths.Count == 0)
                 {
                     return null;
                 }
 
-                var editorConfigDocuments = editorConfigPaths.Select(
-                    path => DocumentInfo.Create(
-                        DocumentId.CreateNewId(projectId),
-                        name: path,
-                        loader: new FileTextLoader(path, Encoding.UTF8),
-                        filePath: path))
-                    .ToImmutableArray();
+                var projectId = ProjectId.CreateNewId(debugName: folderPath);
 
                 return ProjectInfo.Create(
                     projectId,
@@ -49,8 +39,22 @@ namespace Microsoft.CodeAnalysis.Tools.Workspaces
                     assemblyName: folderPath,
                     Language,
                     filePath: folderPath,
-                    documents: documents)
-                    .WithAnalyzerConfigDocuments(editorConfigDocuments);
+                    documents: LoadDocuments(projectId, projectFilePaths.ToImmutable()))
+                    .WithAnalyzerConfigDocuments(LoadDocuments(projectId, editorConfigPaths));
+
+                static IEnumerable<DocumentInfo> LoadDocuments(ProjectId projectId, ImmutableArray<string> filePaths)
+                {
+                    var documents = new DocumentInfo[filePaths.Length];
+                    for (var index = 0; index < filePaths.Length; index++)
+                    {
+                        documents[index] = DocumentInfo.Create(
+                            DocumentId.CreateNewId(projectId, debugName: filePaths[index]),
+                            name: filePaths[index],
+                            loader: new FileTextLoader(filePaths[index], DefaultEncoding),
+                            filePath: filePaths[index]);
+                    }
+                    return documents;
+                }
             }
         }
     }

--- a/tests/CodeFormatterTests.cs
+++ b/tests/CodeFormatterTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;

--- a/tests/CodeFormatterTests.cs
+++ b/tests/CodeFormatterTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         private const string CodeStyleSolutionPath = "for_code_formatter/codestyle_solution/";
         private const string CodeStyleSolutionFilePath = CodeStyleSolutionPath + "codestyle_solution.sln";
 
-        private static IEnumerable<string> EmptyFilesList => Array.Empty<string>();
+        private static string[] EmptyFilesList => Array.Empty<string>();
 
         private Regex FindFormattingLogLine => new Regex(@"((.*)\(\d+,\d+\): (.*))\r|((.*)\(\d+,\d+\): (.*))");
 
@@ -415,8 +415,8 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
 
         public async Task<string> TestFormatWorkspaceAsync(
             string workspaceFilePath,
-            IEnumerable<string> include,
-            IEnumerable<string> exclude,
+            string[] include,
+            string[] exclude,
             bool includeGenerated,
             int expectedExitCode,
             int expectedFilesFormatted,


### PR DESCRIPTION
Improve https://github.com/dotnet/format/issues/757. This PR does a few things. 

- Removes Linq from the FolderWorkspace classes
- Special case when --include is only a list of filenames (no globs or folders)
- Extracts report writing out of the CodeFormatter class