### PR TITLE
Support generated_code editorconfig setting

### DIFF
--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -219,7 +219,11 @@ namespace Microsoft.CodeAnalysis.Tools
                     var analyzerConfigOptions = document.Project.AnalyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree);
                     if (analyzerConfigOptions != null)
                     {
-                        documentsCoveredByEditorConfig.Add(document.Id);
+                        if (formatOptions.IncludeGeneratedFiles ||
+                            GeneratedCodeUtilities.GetIsGeneratedCodeFromOptions(analyzerConfigOptions) != true)
+                        {
+                            documentsCoveredByEditorConfig.Add(document.Id);
+                        }
                     }
                     else
                     {

--- a/src/Utilities/GeneratedCodeUtilities.cs
+++ b/src/Utilities/GeneratedCodeUtilities.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.Tools.Utilities
 {
@@ -90,6 +91,20 @@ namespace Microsoft.CodeAnalysis.Tools.Utilities
             }
 
             return false;
+        }
+
+        internal static bool? GetIsGeneratedCodeFromOptions(AnalyzerConfigOptions options)
+        {
+            // Check for explicit user configuration for generated code.
+            //     generated_code = true | false
+            if (options.TryGetValue("generated_code", out var optionValue) &&
+                bool.TryParse(optionValue, out var boolValue))
+            {
+                return boolValue;
+            }
+
+            // Either no explicit user configuration or we don't recognize the option value.
+            return null;
         }
     }
 }

--- a/tests/CodeFormatterTests.cs
+++ b/tests/CodeFormatterTests.cs
@@ -28,6 +28,9 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         private const string FSharpProjectPath = "for_code_formatter/fsharp_project/";
         private const string FSharpProjectFilePath = FSharpProjectPath + "fsharp_project.fsproj";
 
+        private const string GeneratedProjectPath = "for_code_formatter/generated_project/";
+        private const string GeneratedProjectFilePath = GeneratedProjectPath + "generated_project.csproj";
+
         private const string CodeStyleSolutionPath = "for_code_formatter/codestyle_solution/";
         private const string CodeStyleSolutionFilePath = CodeStyleSolutionPath + "codestyle_solution.sln";
 
@@ -366,6 +369,32 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
                 expectedExitCode: 0,
                 expectedFilesFormatted: 0,
                 expectedFileCount: 5);
+        }
+
+        [Fact]
+        public async Task NoFilesFormattedInGeneratedProject_WhenNotIncludingGeneratedCode()
+        {
+            await TestFormatWorkspaceAsync(
+                GeneratedProjectFilePath,
+                include: EmptyFilesList,
+                exclude: EmptyFilesList,
+                includeGenerated: false,
+                expectedExitCode: 0,
+                expectedFilesFormatted: 0,
+                expectedFileCount: 1);
+        }
+
+        [Fact]
+        public async Task FilesFormattedInGeneratedProject_WhenIncludingGeneratedCode()
+        {
+            await TestFormatWorkspaceAsync(
+                GeneratedProjectFilePath,
+                include: EmptyFilesList,
+                exclude: EmptyFilesList,
+                includeGenerated: true,
+                expectedExitCode: 0,
+                expectedFilesFormatted: 1,
+                expectedFileCount: 1);
         }
 
         [Fact]

--- a/tests/CodeFormatterTests.cs
+++ b/tests/CodeFormatterTests.cs
@@ -381,7 +381,7 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
                 includeGenerated: false,
                 expectedExitCode: 0,
                 expectedFilesFormatted: 0,
-                expectedFileCount: 1);
+                expectedFileCount: 3);
         }
 
         [Fact]
@@ -393,8 +393,8 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
                 exclude: EmptyFilesList,
                 includeGenerated: true,
                 expectedExitCode: 0,
-                expectedFilesFormatted: 1,
-                expectedFileCount: 1);
+                expectedFilesFormatted: 3,
+                expectedFileCount: 3);
         }
 
         [Fact]

--- a/tests/projects/for_code_formatter/generated_project/.editorconfig
+++ b/tests/projects/for_code_formatter/generated_project/.editorconfig
@@ -1,0 +1,149 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+## All files should be considered generated code.
+generated_code = true
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 2
+indent_style = space
+tab_width = 2
+
+# New line preferences
+# end_of_line = crlf
+insert_final_newline = false
+
+#### .NET Coding Conventions ####
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = false:silent
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_property = false:silent
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+
+# Expression-level preferences
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_throw_expression = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+
+# Field preferences
+dotnet_style_readonly_field = true:suggestion
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:suggestion
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = false:silent
+csharp_style_var_for_built_in_types = false:silent
+csharp_style_var_when_type_is_apparent = false:silent
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+
+# Code-block preferences
+csharp_prefer_braces = true:silent
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+

--- a/tests/projects/for_code_formatter/generated_project/Program.cs
+++ b/tests/projects/for_code_formatter/generated_project/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace for_code_formatter
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/tests/projects/for_code_formatter/generated_project/generated_project.csproj
+++ b/tests/projects/for_code_formatter/generated_project/generated_project.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
When the .editorconfig specifies that files are `generated_code`, then we should treat them as generated code files.

fixes https://github.com/dotnet/format/issues/771