### PR TITLE
Fix markdown formatting in example table

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,12 +128,9 @@ Add `format` after `dotnet` and before the command arguments that you want to ru
 | `dotnet format --include Programs.cs Utility\Logging.cs`         | Formats the files Program.cs and Utility\Logging.cs                                                |
 | `dotnet format --check`                                          | Formats but does not save. Returns a non-zero exit code if any files would have been changed.      |
 | `dotnet format --report <report-path>`                           | Formats and saves a json report file to the given directory.                                       |
-| `dotnet format --include test/Utilities/*.cs --folder`           | Formats the files expanded from native shell globbing (e.g. bash). Space-separated list of         |
-|                                                                  | files are fed to formatter in this case. Also applies to `--exclude` option.                       |
-| `dotnet format --include 'test/Utilities/*.cs' --folder`         | With single quotes, formats the files expanded from built-in glob expansion. A single file         |
-|                                                                  | pattern is fed to formatter, which gets expanded internally. Also applies to `--exclude` option.   |
-| `ls tests/Utilities/*.cs \| dotnet format --include - --folder`  | Formats the list of files redirected from pipeline via standard input. Formatter will iterate over |
-|                                                                  | `Console.In` to read the list of files. Also applies to `--exclude` option.                        |
+| `dotnet format --include test/Utilities/*.cs --folder`           | Formats the files expanded from native shell globbing (e.g. bash). Space-separated list of files are fed to formatter in this case. Also applies to `--exclude` option. |
+| `dotnet format --include 'test/Utilities/*.cs' --folder`         | With single quotes, formats the files expanded from built-in glob expansion. A single file pattern is fed to formatter, which gets expanded internally. Also applies to `--exclude` option. |
+| `ls tests/Utilities/*.cs \| dotnet format --include - --folder`  | Formats the list of files redirected from pipeline via standard input. Formatter will iterate over `Console.In` to read the list of files. Also applies to `--exclude` option. |
 
 ### How To Uninstall
 


### PR DESCRIPTION
@jmarolf, sorry I've just noticed that the markdown in the README did not wrap the lines in rendered view as I was expecting. We can either wrap the code and get the bad/unexpected rendered view or have long lines in code to get the text wrapped nicely in the rendered view (limitation of GH markdown).

This changes the table layout in rendered view from
<img width="877" alt="image" src="https://user-images.githubusercontent.com/3840695/98581872-c93eb400-22ca-11eb-988e-585c79993752.png">
to
<img width="871" alt="image" src="https://user-images.githubusercontent.com/3840695/98581969-f4290800-22ca-11eb-886a-f5b2f89e9944.png">
