### PR TITLE
When matching all files don't rely on FileMatcher

### DIFF
--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.Tools
                     addedFilePaths.Add(document.FilePath);
 
                     var isFileIncluded = formatOptions.WorkspaceType == WorkspaceType.Folder ||
-                        (formatOptions.FileMatcher.Match(document.FilePath).HasMatches && File.Exists(document.FilePath));
+                        (formatOptions.FileMatcher.HasMatches(document.FilePath) && File.Exists(document.FilePath));
                     if (!isFileIncluded || !document.SupportsSyntaxTree)
                     {
                         continue;

--- a/src/Utilities/SourceFileMatcher.cs
+++ b/src/Utilities/SourceFileMatcher.cs
@@ -12,16 +12,21 @@ namespace Microsoft.CodeAnalysis.Tools.Utilities
         private static string[] AllFilesList => new[] { @"**/*.*" };
 
         public static SourceFileMatcher CreateMatcher(string[] include, string[] exclude)
-            => new SourceFileMatcher(include.Length > 0 ? include : AllFilesList, exclude);
+            => new SourceFileMatcher(include, exclude);
 
         private readonly Matcher _matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
+        private readonly bool _shouldMatchAll;
 
         public ImmutableArray<string> Include { get; }
         public ImmutableArray<string> Exclude { get; }
 
         private SourceFileMatcher(string[] include, string[] exclude)
         {
-            Include = include.ToImmutableArray();
+            _shouldMatchAll = include.Length == 0 && exclude.Length == 0;
+
+            Include = include.Length > 0
+                ? include.ToImmutableArray()
+                : AllFilesList.ToImmutableArray();
             Exclude = exclude.ToImmutableArray();
 
             _matcher = new Matcher(StringComparison.OrdinalIgnoreCase);
@@ -29,8 +34,8 @@ namespace Microsoft.CodeAnalysis.Tools.Utilities
             _matcher.AddExcludePatterns(Exclude);
         }
 
-        public PatternMatchingResult Match(string filePath)
-            => _matcher.Match(filePath);
+        public bool HasMatches(string filePath)
+            => _shouldMatchAll || _matcher.Match(filePath).HasMatches;
 
         public IEnumerable<string> GetResultsInFullPath(string directoryPath)
             => _matcher.GetResultsInFullPath(directoryPath);


### PR DESCRIPTION
When Including "**/\*.\*" (All files in all directories), the file matcher doesn't return matches for valid filenames. This PR skips checking the file matcher when we are matching all files.

Resolves #809 