### PR TITLE
Only run analyzers against specified project when workspace is a project

### DIFF
--- a/src/Analyzers/AnalyzerFormatter.cs
+++ b/src/Analyzers/AnalyzerFormatter.cs
@@ -106,7 +106,10 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
             CancellationToken cancellationToken)
         {
             var result = new CodeAnalysisResult();
-            foreach (var project in solution.Projects)
+            var projects = options.WorkspaceType == WorkspaceType.Solution
+                ? solution.Projects
+                : solution.Projects.Where(project => project.FilePath == options.WorkspaceFilePath);
+            foreach (var project in projects)
             {
                 var analyzers = projectAnalyzers[project.Id];
                 if (analyzers.IsEmpty)


### PR DESCRIPTION
We only perform whitespace formatting against the specfied project when the workspace type is project. This updates the analyzer runner with the same behavior. This will skip running analyzers against referenced projects.