### PR TITLE
Search .editorconfig only in relevant directories

### DIFF
--- a/src/Workspaces/FolderWorkspace_FolderSolutionLoader.cs
+++ b/src/Workspaces/FolderWorkspace_FolderSolutionLoader.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Tools.Workspaces
                 var absoluteFolderPath = Path.GetFullPath(folderPath, Directory.GetCurrentDirectory());
 
                 var filePaths = GetMatchingFilePaths(absoluteFolderPath, fileMatcher);
-                var editorConfigPaths = EditorConfigFinder.GetEditorConfigPaths(folderPath);
+                var editorConfigPaths = EditorConfigFinder.GetEditorConfigPaths(filePaths);
 
                 var projectInfos = ImmutableArray.CreateBuilder<ProjectInfo>(ProjectLoaders.Length);
 


### PR DESCRIPTION
Currently we are searching .editorconfig in:

1. child directories
2. parent directories up to the root

However, roslyn only performs <span>#</span>2: [ProjectExtensions.cs#L51](https://github.com/dotnet/roslyn/blob/d66c12164c0da3841f86b165872ea1b55942c575/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/Core/Extensions/ProjectExtensions.cs#L51). Editor config's official docs also attest to that being the only criteria as far as far as "walking the filesystem" goes: https://editorconfig.org/#file-location.

The typical configuration systems in many tools of linter, compiler and transpiler categories use the following mechanism with intuitive/easy-to-remember overriding/precedence rules for developers:

1. accept config file path via command-line argument and use that.
2. if <span>#</span>1 is not present, then look for the environment variable, e.g. DOTNET_EDITORCONFIG_PATH or simply EDITORCONFIG_PATH.
3. if <span>#</span>2 is not present, then look in parent directories up to the volume root.
4. if <span>#</span>3 is not present, then look in $HOME directory.

As roslyn also has a TODO to improve the heuristics and currently only performs search in parent directories per the docs, this PR aims to only fix the bug. In future, we may want to improve the heuristics based on the aforementioned well-known convention.

Before it was taking 22425ms to format _one_ .cs file in a directory with nested subdirectories on my system. After this fix, it took 1351ms for the same file at the same location.