### PR TITLE
Isolate each Analyzer assembly into its own LoadContext.

### DIFF
--- a/src/Analyzers/AnalyzerReferenceInformationProvider.cs
+++ b/src/Analyzers/AnalyzerReferenceInformationProvider.cs
@@ -23,10 +23,8 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
 
         private AnalyzersAndFixers GetAnalyzersAndFixers(Project project)
         {
-            var context = new AnalyzerLoadContext();
-
             var analyzerAssemblies = project.AnalyzerReferences
-                .Select(reference => TryLoadAssemblyFrom(reference.FullPath, context))
+                .Select(reference => TryLoadAssemblyFrom(reference.FullPath, new AnalyzerLoadContext()))
                 .OfType<Assembly>()
                 .ToImmutableArray();
 

--- a/src/Analyzers/SolutionCodeFixApplier.cs
+++ b/src/Analyzers/SolutionCodeFixApplier.cs
@@ -109,9 +109,10 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
                 return GetProjectDiagnosticsAsync(project, cancellationToken);
             }
 
-            public override Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
+            public override async Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
             {
-                throw new NotImplementedException();
+                var projectDiagnostics = await GetProjectDiagnosticsAsync(document.Project, cancellationToken);
+                return projectDiagnostics.Where(diagnostic => diagnostic.Location.SourceTree?.FilePath == document.FilePath).ToImmutableArray();
             }
 
             public override Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(Project project, CancellationToken cancellationToken)

--- a/tests/Analyzers/ThirdPartyAnalyzerFormatterTests.cs
+++ b/tests/Analyzers/ThirdPartyAnalyzerFormatterTests.cs
@@ -120,9 +120,56 @@ class C
         }
 
         [Fact]
-        public async Task TestIDisposableAnalyzer_Loads()
+        public async Task TestIDisposableAnalyzer_AddsUsing()
         {
             var analyzerReferences = GetAnalyzerReferences("IDisposable");
+
+            var testCode = @"
+using System.IO;
+
+class C
+{
+    void M()
+    {
+        var stream = File.OpenRead(string.Empty);
+        var b = stream.ReadByte();
+        stream.Dispose();
+    }
+}
+";
+
+            var expectedCode = @"
+using System.IO;
+
+class C
+{
+    void M()
+    {
+        using (var stream = File.OpenRead(string.Empty))
+        {
+            var b = stream.ReadByte();
+        }
+    }
+}
+";
+
+            var editorConfig = new Dictionary<string, string>()
+            {
+                // Turn off all diagnostics analyzers
+                ["dotnet_analyzer_diagnostic.severity"] = "none",
+
+                // Prefer using. IDISP017
+                ["dotnet_diagnostic.IDISP017.severity"] = "error",
+            };
+
+            await AssertCodeChangedAsync(testCode, expectedCode, editorConfig, fixCategory: FixCategory.Analyzers, analyzerReferences: analyzerReferences);
+        }
+
+        [Fact]
+        public async Task TestLoadingAllAnalyzers_LoadsDependenciesFromAllSearchPaths()
+        {
+            // Loads all analyzer references.
+            var analyzerReferences = _analyzerReferencesProject.AnalyzerReferences;
 
             var testCode = @"
 using System.IO;

--- a/tests/Analyzers/ThirdPartyAnalyzerFormatterTests.cs
+++ b/tests/Analyzers/ThirdPartyAnalyzerFormatterTests.cs
@@ -118,5 +118,51 @@ class C
 
             await AssertCodeChangedAsync(testCode, expectedCode, editorConfig, fixCategory: FixCategory.Analyzers, analyzerReferences: analyzerReferences);
         }
+
+        [Fact]
+        public async Task TestIDisposableAnalyzer_Loads()
+        {
+            var analyzerReferences = GetAnalyzerReferences("IDisposable");
+
+            var testCode = @"
+using System.IO;
+
+class C
+{
+    void M()
+    {
+        var stream = File.OpenRead(string.Empty);
+        var b = stream.ReadByte();
+        stream.Dispose();
+    }
+}
+";
+
+            var expectedCode = @"
+using System.IO;
+
+class C
+{
+    void M()
+    {
+        using (var stream = File.OpenRead(string.Empty))
+        {
+            var b = stream.ReadByte();
+        }
+    }
+}
+";
+
+            var editorConfig = new Dictionary<string, string>()
+            {
+                // Turn off all diagnostics analyzers
+                ["dotnet_analyzer_diagnostic.severity"] = "none",
+
+                // Prefer using. IDISP017
+                ["dotnet_diagnostic.IDISP017.severity"] = "error",
+            };
+
+            await AssertCodeChangedAsync(testCode, expectedCode, editorConfig, fixCategory: FixCategory.Analyzers, analyzerReferences: analyzerReferences);
+        }
     }
 }

--- a/tests/projects/for_analyzer_formatter/analyzer_project/NuGet.config
+++ b/tests/projects/for_analyzer_formatter/analyzer_project/NuGet.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources />
+</configuration>

--- a/tests/projects/for_analyzer_formatter/analyzer_project/analyzer_project.csproj
+++ b/tests/projects/for_analyzer_formatter/analyzer_project/analyzer_project.csproj
@@ -9,6 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="AspNetCoreAnalyzers" Version="0.2.0.1-dev" PrivateAssets="all" />
     <PackageReference Include="IDisposableAnalyzers" Version="3.4.8" PrivateAssets="all" />
   </ItemGroup>
 

--- a/tests/projects/for_analyzer_formatter/analyzer_project/analyzer_project.csproj
+++ b/tests/projects/for_analyzer_formatter/analyzer_project/analyzer_project.csproj
@@ -9,6 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="IDisposableAnalyzers" Version="3.4.8" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Depends on #958 

To avoid dependency versioning issues when loading analyzer assemblies, load each assembly into its own context.

Fixes https://github.com/dotnet/format/issues/957