### PR TITLE
Only report fixable compiler diagnostics.

### DIFF
--- a/src/Analyzers/Interfaces/IAnalyzerRunner.cs
+++ b/src/Analyzers/Interfaces/IAnalyzerRunner.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
             Project project,
             ImmutableHashSet<string> formattableDocumentPaths,
             DiagnosticSeverity severity,
-            bool includeCompilerDiagnostics,
+            ImmutableHashSet<string> fixableCompilerDiagnostics,
             ILogger logger,
             CancellationToken cancellationToken);
 
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
             Project project,
             ImmutableHashSet<string> formattableDocumentPaths,
             DiagnosticSeverity severity,
-            bool includeCompilerDiagnostics,
+            ImmutableHashSet<string> fixableCompilerDiagnostics,
             ILogger logger,
             CancellationToken cancellationToken);
     }

--- a/tests/Analyzers/CodeStyleAnalyzerFormatterTests.cs
+++ b/tests/Analyzers/CodeStyleAnalyzerFormatterTests.cs
@@ -59,5 +59,20 @@ class C
 
             await AssertCodeChangedAsync(testCode, expectedCode, editorConfig, fixCategory: FixCategory.CodeStyle);
         }
+
+        [Fact]
+        public async Task TestNonFixableCompilerDiagnostics_AreNotReported()
+        {
+            var testCode = @"
+class C
+{
+    public int M()
+    {
+        return null; // Cannot convert null to 'int' because it is a non-nullable value type (CS0037)
+    }
+}";
+
+            await AssertNoReportedFileChangesAsync(testCode, "root = true", fixCategory: FixCategory.CodeStyle, codeStyleSeverity: DiagnosticSeverity.Warning);
+        }
     }
 }


### PR DESCRIPTION
Partially addresses the issues raised in https://github.com/dotnet/format/issues/971.

This will filter out compiler diagnostics that do not have an associated CodeFixProvider.