### PR TITLE
LogDebug each project's applied .editorconfig

### DIFF
--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -51,6 +51,17 @@ namespace Microsoft.CodeAnalysis.Tools
                 return new WorkspaceFormatResult(filesFormatted: 0, fileCount: 0, exitCode: 1);
             }
 
+            if (formatOptions.LogLevel <= LogLevel.Debug)
+            {
+                foreach (var project in workspace.CurrentSolution.Projects)
+                {
+                    foreach (var configDocument in project.AnalyzerConfigDocuments)
+                    {
+                        logger.LogDebug(Resources.Project_0_is_using_configuration_from_1, project.Name, configDocument.FilePath);
+                    }
+                }
+            }
+
             var loadWorkspaceMS = workspaceStopwatch.ElapsedMilliseconds;
             logger.LogTrace(Resources.Complete_in_0_ms, loadWorkspaceMS);
 

--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -309,4 +309,7 @@
   <data name="Cannot_specify_the_folder_option_when_fixing_style" xml:space="preserve">
     <value>Cannot specify the '--folder' option when fixing style.</value>
   </data>
+  <data name="Project_0_is_using_configuration_from_1" xml:space="preserve">
+    <value>Project {0} is using configuration from '{1}'.</value>
+  </data>
 </root>

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -167,6 +167,11 @@
         <target state="translated">{0} obsahuje více souborů řešení MSBuild. Určete, který soubor chcete použít, pomocí argumentu &lt;workspace&gt;.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_is_using_configuration_from_1">
+        <source>Project {0} is using configuration from '{1}'.</source>
+        <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">
         <source>Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</source>
         <target state="new">Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</target>

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -167,6 +167,11 @@
         <target state="translated">In "{0}" wurden mehrere MSBuild-Projektmappendateien gefunden. Geben Sie die zu verwendende Datei mit dem &lt;workspace&gt;-Argument an.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_is_using_configuration_from_1">
+        <source>Project {0} is using configuration from '{1}'.</source>
+        <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">
         <source>Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</source>
         <target state="new">Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</target>

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Se encontraron varios archivos de solución MSBuild en "{0}". Especifique cuál debe usarse con el argumento &lt;workspace&gt;.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_is_using_configuration_from_1">
+        <source>Project {0} is using configuration from '{1}'.</source>
+        <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">
         <source>Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</source>
         <target state="new">Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</target>

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Plusieurs fichiers solution MSBuild trouvés dans '{0}'. Spécifiez celui qui doit être utilisé avec l'argument &lt;espace de travail&gt;.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_is_using_configuration_from_1">
+        <source>Project {0} is using configuration from '{1}'.</source>
+        <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">
         <source>Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</source>
         <target state="new">Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</target>

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -167,6 +167,11 @@
         <target state="translated">In '{0}' sono stati trovati più file di soluzione MSBuild. Per specificare quello desiderato, usare l'argomento &lt;workspace&gt;.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_is_using_configuration_from_1">
+        <source>Project {0} is using configuration from '{1}'.</source>
+        <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">
         <source>Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</source>
         <target state="new">Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</target>

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -167,6 +167,11 @@
         <target state="translated">複数の MSBuild ソリューション ファイルが '{0}' で見つかりました。使用するものを &lt;workspace&gt; 引数で指定してください。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_is_using_configuration_from_1">
+        <source>Project {0} is using configuration from '{1}'.</source>
+        <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">
         <source>Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</source>
         <target state="new">Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</target>

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -167,6 +167,11 @@
         <target state="translated">'{0}'에 여러 MSBuild 솔루션 파일이 있습니다. &lt;workspace&gt; 인수를 사용하여 사용할 파일을 지정하세요.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_is_using_configuration_from_1">
+        <source>Project {0} is using configuration from '{1}'.</source>
+        <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">
         <source>Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</source>
         <target state="new">Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</target>

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -167,6 +167,11 @@
         <target state="translated">W elemencie „{0}” znaleziono wiele plików rozwiązań MSBuild. Określ plik do użycia za pomocą argumentu &lt;workspace&gt;.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_is_using_configuration_from_1">
+        <source>Project {0} is using configuration from '{1}'.</source>
+        <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">
         <source>Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</source>
         <target state="new">Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</target>

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -167,6 +167,11 @@
         <target state="translated">Foram encontrados vários arquivos de solução do MSBuild em '{0}'. Especifique qual será usado com o argumento &lt;workspace&gt;.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_is_using_configuration_from_1">
+        <source>Project {0} is using configuration from '{1}'.</source>
+        <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">
         <source>Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</source>
         <target state="new">Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</target>

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -167,6 +167,11 @@
         <target state="translated">В "{0}" обнаружено несколько файлов решения MSBuild. Укажите используемый файл с помощью аргумента &lt;workspace&gt;.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_is_using_configuration_from_1">
+        <source>Project {0} is using configuration from '{1}'.</source>
+        <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">
         <source>Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</source>
         <target state="new">Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</target>

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -167,6 +167,11 @@
         <target state="translated">'{0}' içinde birden fazla MSBuild çözüm dosyası bulundu. Hangisinin &lt;çalışma alanı&gt; bağımsız değişkeni ile kullanılacağını belirtin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_is_using_configuration_from_1">
+        <source>Project {0} is using configuration from '{1}'.</source>
+        <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">
         <source>Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</source>
         <target state="new">Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</target>

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -167,6 +167,11 @@
         <target state="translated">在“{0}”中找到多个 MSBuild 解决方案文件。请指定要用于 &lt;workspace&gt; 参数的文件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_is_using_configuration_from_1">
+        <source>Project {0} is using configuration from '{1}'.</source>
+        <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">
         <source>Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</source>
         <target state="new">Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</target>

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -167,6 +167,11 @@
         <target state="translated">在 '{0}' 中找到多個 MSBuild 解決方案檔。請指定要用於 &lt;workspace&gt; 引數的檔案。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Project_0_is_using_configuration_from_1">
+        <source>Project {0} is using configuration from '{1}'.</source>
+        <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">
         <source>Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</source>
         <target state="new">Required references did not load for {0} or referenced project. Run `dotnet restore` prior to formatting.</target>


### PR DESCRIPTION
Resolves #937

*Example output:*
```console
  The dotnet format version is '5.1.0-dev'.
  The dotnet runtime version is '6.0.0-alpha.1.21064.11'.
  The dotnet CLI version is '6.0.100-alpha.1.21065.7'.
  Using MSBuild.exe located in '/usr/local/share/dotnet/sdk/6.0.100-alpha.1.21065.7/'.
  Formatting code files in workspace '/Users/joeyrobichaud/Source/format/format.sln'.
  Loading workspace.
  Project dotnet-format is using configuration from '/Users/joeyrobichaud/Source/format/.editorconfig'.
  Project dotnet-format.UnitTests is using configuration from '/Users/joeyrobichaud/Source/format/artifacts/obj/dotnet-format.UnitTests/Debug/netcoreapp2.1/dotnet-format.UnitTests.GeneratedMSBuildEditorConfig.editorconfig'.
  Project dotnet-format.UnitTests is using configuration from '/Users/joeyrobichaud/Source/format/.editorconfig'.
  Project dotnet-format.Performance is using configuration from '/Users/joeyrobichaud/Source/format/.editorconfig'.
  Complete in 9725ms.
  Determining formattable files.
  Complete in 1819ms.
  Running formatters.
  Running Code Style analysis.
  Determining diagnostics...
  Running 22 analyzers on dotnet-format.
  Running 22 analyzers on dotnet-format.UnitTests.
  Running 22 analyzers on dotnet-format.Performance.
  Complete in 27916ms.
  Analysis complete in 27916ms.
  Complete in 29163ms.
  Formatted 0 of 97 files.
  Format complete in 40709ms.

```