### PR TITLE
Log all formatter error messages in a csc-style

### DIFF
--- a/src/Analyzers/AnalyzerFormatter.cs
+++ b/src/Analyzers/AnalyzerFormatter.cs
@@ -151,7 +151,7 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
 
                 foreach (var diagnostic in diagnostics)
                 {
-                    var message = $"{diagnostic.GetMessage()} ({diagnostic.Id})";
+                    var message = $"{diagnostic.Severity.ToString().ToLower()} {diagnostic.Id}: {diagnostic.GetMessage()}";
                     var document = solution.GetDocument(diagnostic.Location.SourceTree);
                     if (document is null)
                     {

--- a/src/Analyzers/AnalyzerFormatter.cs
+++ b/src/Analyzers/AnalyzerFormatter.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Analyzers/AnalyzerFormatter.cs
+++ b/src/Analyzers/AnalyzerFormatter.cs
@@ -163,7 +163,7 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
                     var mappedLineSpan = diagnostic.Location.GetMappedLineSpan();
                     var changePosition = mappedLineSpan.StartLinePosition;
 
-                    var formatMessage = $"{Path.GetRelativePath(workspaceFolder, filePath)}({changePosition.Line + 1},{changePosition.Character + 1}): {message}";
+                    var formatMessage = $"{filePath}({changePosition.Line + 1},{changePosition.Character + 1}): {message} [{document.Project.FilePath}]";
                     formattedFiles.Add(new FormattedFile(document!, new[] { new FileChange(changePosition, message) }));
 
                     if (changesAreErrors)

--- a/src/Analyzers/AnalyzerFormatter.cs
+++ b/src/Analyzers/AnalyzerFormatter.cs
@@ -141,39 +141,29 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
                 await _runner.RunCodeAnalysisAsync(result, analyzers, project, formattablePaths, severity, fixableCompilerDiagnostics, logger, cancellationToken).ConfigureAwait(false);
             }
 
-            LogDiagnosticLocations(solution, result.Diagnostics.SelectMany(kvp => kvp.Value), options.WorkspaceFilePath, options.ChangesAreErrors, logger, formattedFiles);
+            LogDiagnosticLocations(solution, result.Diagnostics.SelectMany(kvp => kvp.Value), options.SaveFormattedFiles, options.ChangesAreErrors, logger, options.LogLevel, formattedFiles);
 
             return result.Diagnostics.ToImmutableDictionary(kvp => kvp.Key.Id, kvp => kvp.Value.Select(diagnostic => diagnostic.Id).ToImmutableHashSet());
 
-            static void LogDiagnosticLocations(Solution solution, IEnumerable<Diagnostic> diagnostics, string workspacePath, bool changesAreErrors, ILogger logger, List<FormattedFile> formattedFiles)
+            static void LogDiagnosticLocations(Solution solution, IEnumerable<Diagnostic> diagnostics, bool saveFormattedFiles, bool changesAreErrors, ILogger logger, LogLevel logLevel, List<FormattedFile> formattedFiles)
             {
-                var workspaceFolder = Path.GetDirectoryName(workspacePath) ?? workspacePath;
-
                 foreach (var diagnostic in diagnostics)
                 {
-                    var message = $"{diagnostic.Severity.ToString().ToLower()} {diagnostic.Id}: {diagnostic.GetMessage()}";
                     var document = solution.GetDocument(diagnostic.Location.SourceTree);
                     if (document is null)
                     {
                         continue;
                     }
 
-                    var filePath = document.FilePath ?? document.Name;
-
                     var mappedLineSpan = diagnostic.Location.GetMappedLineSpan();
-                    var changePosition = mappedLineSpan.StartLinePosition;
+                    var diagnosticPosition = mappedLineSpan.StartLinePosition;
 
-                    var formatMessage = $"{filePath}({changePosition.Line + 1},{changePosition.Character + 1}): {message} [{document.Project.FilePath}]";
-                    formattedFiles.Add(new FormattedFile(document!, new[] { new FileChange(changePosition, message) }));
+                    if (!saveFormattedFiles || logLevel == LogLevel.Debug)
+                    {
+                        logger.LogDiagnosticIssue(document, diagnosticPosition, diagnostic, changesAreErrors);
+                    }
 
-                    if (changesAreErrors)
-                    {
-                        logger.LogError(formatMessage);
-                    }
-                    else
-                    {
-                        logger.LogWarning(formatMessage);
-                    }
+                    formattedFiles.Add(new FormattedFile(document, new[] { new FileChange(diagnosticPosition, $"{diagnostic.Severity.ToString().ToLower()} {diagnostic.Id}: {diagnostic.GetMessage()}") }));
                 }
             }
         }

--- a/src/Formatters/CharsetFormatter.cs
+++ b/src/Formatters/CharsetFormatter.cs
@@ -20,6 +20,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
         private static Encoding Utf8 => new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
         private static Encoding Latin1 => Encoding.GetEncoding("iso-8859-1");
 
+        public override string Name => "CHARSET";
         public override FixCategory Category => FixCategory.Whitespace;
 
         internal override Task<SourceText> FormatFileAsync(

--- a/src/Formatters/DocumentFormatter.cs
+++ b/src/Formatters/DocumentFormatter.cs
@@ -166,26 +166,13 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
                 var fileChange = new FileChange(changePosition, FormatWarningDescription);
                 fileChanges.Add(fileChange);
 
-                if (!formatOptions.SaveFormattedFiles || formatOptions.LogLevel == LogLevel.Trace)
+                if (!formatOptions.SaveFormattedFiles || formatOptions.LogLevel == LogLevel.Debug)
                 {
-                    LogFormattingChanges(document, changesAreErrors, logger, fileChange);
+                    logger.LogFormattingIssue(document, Name, fileChange, changesAreErrors);
                 }
             }
 
             return fileChanges.ToImmutable();
-        }
-
-        private void LogFormattingChanges(Document document, bool changesAreErrors, ILogger logger, FileChange fileChange)
-        {
-            var formatMessage = $"{document.FilePath}({fileChange.LineNumber},{fileChange.CharNumber}): error {Name}: {fileChange.FormatDescription} [{document.Project.FilePath}]";
-            if (changesAreErrors)
-            {
-                logger.LogError(formatMessage);
-            }
-            else
-            {
-                logger.LogWarning(formatMessage);
-            }
         }
 
         protected static async Task<bool> IsSameDocumentAndVersionAsync(Document a, Document b, CancellationToken cancellationToken)

--- a/src/Formatters/DocumentFormatter.cs
+++ b/src/Formatters/DocumentFormatter.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/Formatters/EndOfLineFormatter.cs
+++ b/src/Formatters/EndOfLineFormatter.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
     {
         protected override string FormatWarningDescription => Resources.Fix_end_of_line_marker;
 
+        public override string Name => "ENDOFLINE";
         public override FixCategory Category => FixCategory.Whitespace;
 
         internal override Task<SourceText> FormatFileAsync(

--- a/src/Formatters/FinalNewlineFormatter.cs
+++ b/src/Formatters/FinalNewlineFormatter.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
     {
         protected override string FormatWarningDescription => Resources.Fix_final_newline;
 
+        public override string Name => "FINALNEWLINE";
         public override FixCategory Category => FixCategory.Whitespace;
 
         internal override async Task<SourceText> FormatFileAsync(

--- a/src/Formatters/OrganizeImportsFormatter.cs
+++ b/src/Formatters/OrganizeImportsFormatter.cs
@@ -20,6 +20,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
         protected override string FormatWarningDescription => Resources.Fix_imports_ordering;
         private readonly DocumentFormatter _endOfLineFormatter = new EndOfLineFormatter();
 
+        public override string Name => "IMPORTS";
         public override FixCategory Category => FixCategory.Whitespace;
 
         internal override async Task<SourceText> FormatFileAsync(

--- a/src/Formatters/UnnecessaryImportsFormatter.cs
+++ b/src/Formatters/UnnecessaryImportsFormatter.cs
@@ -20,6 +20,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
 
         protected override string FormatWarningDescription => Resources.Remove_unnecessary_import;
 
+        public override string Name => IDE0005;
         public override FixCategory Category => FixCategory.CodeStyle;
 
         internal override async Task<SourceText> FormatFileAsync(

--- a/src/Formatters/WhitespaceFormatter.cs
+++ b/src/Formatters/WhitespaceFormatter.cs
@@ -17,6 +17,7 @@ namespace Microsoft.CodeAnalysis.Tools.Formatters
     {
         protected override string FormatWarningDescription => Resources.Fix_whitespace_formatting;
 
+        public override string Name => "WHITESPACE";
         public override FixCategory Category => FixCategory.Whitespace;
 
         internal override async Task<SourceText> FormatFileAsync(

--- a/src/Logging/IIssueFormatter.cs
+++ b/src/Logging/IIssueFormatter.cs
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Tools.Logging
+{
+    public interface IIssueFormatter
+    {
+        string FormatIssue(Document document, string severity, string issueId, int lineNumber, int charNumber, string message);
+    }
+}

--- a/src/Logging/IIssueFormatter.cs
+++ b/src/Logging/IIssueFormatter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 namespace Microsoft.CodeAnalysis.Tools.Logging
 {

--- a/src/Logging/ILoggerExtensions.cs
+++ b/src/Logging/ILoggerExtensions.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Tools.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.CodeAnalysis.Tools
+{
+    internal static class ILoggerExtensions
+    {
+        private static readonly string s_errorSeverityString = DiagnosticSeverity.Error.ToString().ToLower();
+
+        public static IIssueFormatter IssueFormatter { get; set; } = new MSBuildIssueFormatter();
+
+        public static string LogFormattingIssue(this ILogger logger, Document document, string formatterName, FileChange fileChange, bool changesAreErrors)
+            => LogIssue(logger, document, s_errorSeverityString, formatterName, fileChange.LineNumber, fileChange.CharNumber, fileChange.FormatDescription, changesAreErrors);
+
+        public static string LogDiagnosticIssue(this ILogger logger, Document document, LinePosition diagnosticPosition, Diagnostic diagnostic, bool changesAreErrors)
+            => LogIssue(logger, document, diagnostic.Severity.ToString().ToLower(), diagnostic.Id, diagnosticPosition.Line + 1, diagnosticPosition.Character + 1, diagnostic.GetMessage(), changesAreErrors);
+
+        private static string LogIssue(ILogger logger, Document document, string severity, string issueId, int lineNumber, int charNumber, string message, bool changesAreErrors)
+        {
+            var formattedMessage = IssueFormatter.FormatIssue(document, severity, issueId, lineNumber, charNumber, message);
+
+            if (changesAreErrors)
+            {
+                logger.LogError(formattedMessage);
+            }
+            else
+            {
+                logger.LogWarning(formattedMessage);
+            }
+
+            return formattedMessage;
+        }
+    }
+}

--- a/src/Logging/ILoggerExtensions.cs
+++ b/src/Logging/ILoggerExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Tools.Logging;

--- a/src/Logging/MSBuildIssueFormatter.cs
+++ b/src/Logging/MSBuildIssueFormatter.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Tools.Logging
+{
+    internal sealed class MSBuildIssueFormatter : IIssueFormatter
+    {
+        public string FormatIssue(Document document, string severity, string issueId, int lineNumber, int charNumber, string message)
+            => $"{document.FilePath ?? document.Name}({lineNumber},{charNumber}): {severity} {issueId}: {message} [{document.Project.FilePath}]";
+    }
+}

--- a/src/Logging/MSBuildIssueFormatter.cs
+++ b/src/Logging/MSBuildIssueFormatter.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 namespace Microsoft.CodeAnalysis.Tools.Logging
 {

--- a/src/Logging/SimpleConsoleLogger.cs
+++ b/src/Logging/SimpleConsoleLogger.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Tools.Logging
         {
             if (logToErrorStream)
             {
-                console.Error.Write($"  {message}{Environment.NewLine}");
+                console.Error.Write($"{message}{Environment.NewLine}");
             }
             else
             {


### PR DESCRIPTION
Resolves #953

*Example msbuild output:*
```console
~/output-test> dotnet build /p:EnforceCodeStyleInBuild=true
Microsoft (R) Build Engine version 16.9.0-preview-21064-01+995458447 for .NET
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  Restored /Users/joeyrobichaud/output-test/output-test.csproj (in 95 ms).
  You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
/Users/joeyrobichaud/output-test/Test0.cs(10,13): warning CS0219: The variable 'count' is assigned but its value is never used [/Users/joeyrobichaud/output-test/output-test.csproj]
/Users/joeyrobichaud/output-test/Test0.cs(8,9): error IDE0007: use 'var' instead of explicit type [/Users/joeyrobichaud/output-test/output-test.csproj]
/Users/joeyrobichaud/output-test/Test0.cs(9,9): error IDE0007: use 'var' instead of explicit type [/Users/joeyrobichaud/output-test/output-test.csproj]
/Users/joeyrobichaud/output-test/Test0.cs(10,9): error IDE0007: use 'var' instead of explicit type [/Users/joeyrobichaud/output-test/output-test.csproj]

Build FAILED.
```

*Example dotnet format diagnostic output*
```console
  The dotnet format version is '5.1.0-dev'.
  The dotnet runtime version is '6.0.0-alpha.1.21064.11'.
  The dotnet CLI version is '6.0.100-alpha.1.21065.7'.
  Using MSBuild.exe located in '/usr/local/share/dotnet/sdk/6.0.100-alpha.1.21065.7/'.
  Formatting code files in workspace '/Users/joeyrobichaud/output-test/output-test.csproj'.
  Loading workspace.
  Project output-test is using configuration from '/Users/joeyrobichaud/output-test/.editorconfig'.
  Project output-test is using configuration from '/Users/joeyrobichaud/output-test/obj/Debug/net5.0/output-test.GeneratedMSBuildEditorConfig.editorconfig'.
  Project output-test is using configuration from '/usr/local/share/dotnet/sdk/6.0.100-alpha.1.21065.7/Sdks/Microsoft.NET.Sdk/analyzers/build/config/AnalysisLevel_5_Default.editorconfig'.
  Complete in 3612ms.
  Determining formattable files.
  Complete in 388ms.
  Running formatters.
  Running Code Style analysis.
  Determining diagnostics...
  Running 4 analyzers on output-test.
/Users/joeyrobichaud/output-test/Test0.cs(8,9): error IDE0007: use 'var' instead of explicit type [/Users/joeyrobichaud/output-test/output-test.csproj]
/Users/joeyrobichaud/output-test/Test0.cs(9,9): error IDE0007: use 'var' instead of explicit type [/Users/joeyrobichaud/output-test/output-test.csproj]
/Users/joeyrobichaud/output-test/Test0.cs(10,9): error IDE0007: use 'var' instead of explicit type [/Users/joeyrobichaud/output-test/output-test.csproj]
/Users/joeyrobichaud/output-test/Test0.cs(10,13): warning CS0219: The variable 'count' is assigned but its value is never used [/Users/joeyrobichaud/output-test/output-test.csproj]
  Complete in 1891ms.
  Analysis complete in 1891ms.
  Complete in 2139ms.
  Formatted code file '/Users/joeyrobichaud/output-test/Test0.cs'.
  Formatted 1 of 4 files.
  Format complete in 6139ms.
```

*Example dotnet format whitespace output*
```console
  The dotnet runtime version is '6.0.0-alpha.1.21064.11'.
  Using MSBuild.exe located in '/usr/local/share/dotnet/sdk/6.0.100-alpha.1.21065.7/'.
  Formatting code files in workspace '/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj'.
  Loading workspace.
  Project unformatted_project is using configuration from '/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/.editorconfig'.
  Project unformatted_project is using configuration from '/Users/joeyrobichaud/Source/format/.editorconfig'.
  Complete in 1947ms.
  Determining formattable files.
  Complete in 341ms.
  Running formatters.
/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/other_items/OtherClass.cs(5,3): error WHITESPACE: Fix whitespace formatting. [/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj]
/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/other_items/OtherClass.cs(6,3): error WHITESPACE: Fix whitespace formatting. [/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj]
/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/other_items/OtherClass.cs(7,5): error WHITESPACE: Fix whitespace formatting. [/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj]
/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/other_items/OtherClass.cs(8,5): error WHITESPACE: Fix whitespace formatting. [/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj]
/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/other_items/OtherClass.cs(9,7): error WHITESPACE: Fix whitespace formatting. [/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj]
/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/other_items/OtherClass.cs(10,5): error WHITESPACE: Fix whitespace formatting. [/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj]
/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/other_items/OtherClass.cs(11,3): error WHITESPACE: Fix whitespace formatting. [/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj]
/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/Program.cs(5,3): error WHITESPACE: Fix whitespace formatting. [/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj]
/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/Program.cs(6,3): error WHITESPACE: Fix whitespace formatting. [/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj]
/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/Program.cs(7,5): error WHITESPACE: Fix whitespace formatting. [/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj]
/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/Program.cs(8,5): error WHITESPACE: Fix whitespace formatting. [/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj]
/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/Program.cs(9,7): error WHITESPACE: Fix whitespace formatting. [/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj]
/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/Program.cs(10,5): error WHITESPACE: Fix whitespace formatting. [/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj]
/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/Program.cs(11,3): error WHITESPACE: Fix whitespace formatting. [/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj]
/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/other_items/OtherClass.cs(12,2): error FINALNEWLINE: Fix final newline. [/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj]
/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/Program.cs(12,2): error FINALNEWLINE: Fix final newline. [/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj]
  Complete in 384ms.
  Formatted code file '/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/other_items/OtherClass.cs'.
  Formatted code file '/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/Program.cs'.
  Formatted 2 of 6 files.
  Format complete in 2673ms.
```