### PR TITLE
Enhance whitespace issue logging with a detailed TextChange message

### DIFF
--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -312,4 +312,13 @@
   <data name="Project_0_is_using_configuration_from_1" xml:space="preserve">
     <value>Project {0} is using configuration from '{1}'.</value>
   </data>
+  <data name="Delete_0_characters" xml:space="preserve">
+    <value>Delete {0} characters.</value>
+  </data>
+  <data name="Insert_0" xml:space="preserve">
+    <value>Insert '{0}'.</value>
+  </data>
+  <data name="Replace_0_characters_with_1" xml:space="preserve">
+    <value>Replace {0} characters with '{1}'.</value>
+  </data>
 </root>

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -72,6 +72,11 @@
         <target state="translated">{0} nejde formátovat. Formátovat jde v současné době jenom projekty v jazycích C# a Visual Basic.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Delete_0_characters">
+        <source>Delete {0} characters.</source>
+        <target state="new">Delete {0} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Determining_diagnostics">
         <source>Determining diagnostics...</source>
         <target state="translated">Zjišťuje se diagnostika...</target>
@@ -152,6 +157,11 @@
         <target state="translated">Zahrňte do operací formátování vygenerované soubory kódu.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Insert_0">
+        <source>Insert '{0}'.</source>
+        <target state="new">Insert '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading_workspace">
         <source>Loading workspace.</source>
         <target state="translated">Načítá se pracovní prostor.</target>
@@ -170,6 +180,11 @@
       <trans-unit id="Project_0_is_using_configuration_from_1">
         <source>Project {0} is using configuration from '{1}'.</source>
         <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Replace_0_characters_with_1">
+        <source>Replace {0} characters with '{1}'.</source>
+        <target state="new">Replace {0} characters with '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -72,6 +72,11 @@
         <target state="translated">"{0}" konnte nicht formatiert werden. Derzeit wird die Formatierung nur für C#- und Visual Basic-Projekte unterstützt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Delete_0_characters">
+        <source>Delete {0} characters.</source>
+        <target state="new">Delete {0} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Determining_diagnostics">
         <source>Determining diagnostics...</source>
         <target state="translated">Diagnose wird ermittelt...</target>
@@ -152,6 +157,11 @@
         <target state="translated">Hiermit werden generierte Codedateien in Formatierungsvorgänge einbezogen.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Insert_0">
+        <source>Insert '{0}'.</source>
+        <target state="new">Insert '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading_workspace">
         <source>Loading workspace.</source>
         <target state="translated">Arbeitsbereich wird geladen.</target>
@@ -170,6 +180,11 @@
       <trans-unit id="Project_0_is_using_configuration_from_1">
         <source>Project {0} is using configuration from '{1}'.</source>
         <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Replace_0_characters_with_1">
+        <source>Replace {0} characters with '{1}'.</source>
+        <target state="new">Replace {0} characters with '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -72,6 +72,11 @@
         <target state="translated">No se pudo dar formato a "{0}". El formato admite solo proyectos de C# y Visual Basic en este momento.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Delete_0_characters">
+        <source>Delete {0} characters.</source>
+        <target state="new">Delete {0} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Determining_diagnostics">
         <source>Determining diagnostics...</source>
         <target state="translated">Determinando los diagnósticos...</target>
@@ -152,6 +157,11 @@
         <target state="translated">Incluya los archivos de código generados en las operaciones de formato.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Insert_0">
+        <source>Insert '{0}'.</source>
+        <target state="new">Insert '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading_workspace">
         <source>Loading workspace.</source>
         <target state="translated">Cargando área de trabajo.</target>
@@ -170,6 +180,11 @@
       <trans-unit id="Project_0_is_using_configuration_from_1">
         <source>Project {0} is using configuration from '{1}'.</source>
         <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Replace_0_characters_with_1">
+        <source>Replace {0} characters with '{1}'.</source>
+        <target state="new">Replace {0} characters with '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Impossible de mettre en forme '{0}'. L'opération Mettre en forme prend uniquement en charge les projets C# et Visual Basic pour le moment.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Delete_0_characters">
+        <source>Delete {0} characters.</source>
+        <target state="new">Delete {0} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Determining_diagnostics">
         <source>Determining diagnostics...</source>
         <target state="translated">Détermination des diagnostics...</target>
@@ -152,6 +157,11 @@
         <target state="translated">Ajoutez des fichiers de code générés dans les opérations de mise en forme.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Insert_0">
+        <source>Insert '{0}'.</source>
+        <target state="new">Insert '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading_workspace">
         <source>Loading workspace.</source>
         <target state="translated">Chargement de l'espace de travail.</target>
@@ -170,6 +180,11 @@
       <trans-unit id="Project_0_is_using_configuration_from_1">
         <source>Project {0} is using configuration from '{1}'.</source>
         <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Replace_0_characters_with_1">
+        <source>Replace {0} characters with '{1}'.</source>
+        <target state="new">Replace {0} characters with '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Non è stato possibile formattare '{0}'. Il formato supporta attualmente solo progetti C# e Visual Basic.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Delete_0_characters">
+        <source>Delete {0} characters.</source>
+        <target state="new">Delete {0} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Determining_diagnostics">
         <source>Determining diagnostics...</source>
         <target state="translated">Determinazione della diagnostica...</target>
@@ -152,6 +157,11 @@
         <target state="translated">Includere i file del codice generato nelle operazioni di formattazione.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Insert_0">
+        <source>Insert '{0}'.</source>
+        <target state="new">Insert '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading_workspace">
         <source>Loading workspace.</source>
         <target state="translated">Caricamento dell'area di lavoro.</target>
@@ -170,6 +180,11 @@
       <trans-unit id="Project_0_is_using_configuration_from_1">
         <source>Project {0} is using configuration from '{1}'.</source>
         <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Replace_0_characters_with_1">
+        <source>Replace {0} characters with '{1}'.</source>
+        <target state="new">Replace {0} characters with '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -72,6 +72,11 @@
         <target state="translated">'{0}' をフォーマットできませんでした。フォーマットは、C# および Visual Basic のプロジェクトでのみサポートされています。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Delete_0_characters">
+        <source>Delete {0} characters.</source>
+        <target state="new">Delete {0} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Determining_diagnostics">
         <source>Determining diagnostics...</source>
         <target state="translated">診断を決定しています...</target>
@@ -152,6 +157,11 @@
         <target state="translated">生成されたコード ファイルを書式設定操作に含めます。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Insert_0">
+        <source>Insert '{0}'.</source>
+        <target state="new">Insert '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading_workspace">
         <source>Loading workspace.</source>
         <target state="translated">ワークスペースを読み込んでいます。</target>
@@ -170,6 +180,11 @@
       <trans-unit id="Project_0_is_using_configuration_from_1">
         <source>Project {0} is using configuration from '{1}'.</source>
         <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Replace_0_characters_with_1">
+        <source>Replace {0} characters with '{1}'.</source>
+        <target state="new">Replace {0} characters with '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -72,6 +72,11 @@
         <target state="translated">'{0}'의 서식을 지정할 수 없습니다. 서식 지정은 현재 C# 및 Visual Basic 프로젝트만 지원합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Delete_0_characters">
+        <source>Delete {0} characters.</source>
+        <target state="new">Delete {0} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Determining_diagnostics">
         <source>Determining diagnostics...</source>
         <target state="translated">진단을 확인하는 중...</target>
@@ -152,6 +157,11 @@
         <target state="translated">서식 지정 작업에서 생성된 코드 파일을 포함합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Insert_0">
+        <source>Insert '{0}'.</source>
+        <target state="new">Insert '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading_workspace">
         <source>Loading workspace.</source>
         <target state="translated">작업 영역을 로드하는 중입니다.</target>
@@ -170,6 +180,11 @@
       <trans-unit id="Project_0_is_using_configuration_from_1">
         <source>Project {0} is using configuration from '{1}'.</source>
         <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Replace_0_characters_with_1">
+        <source>Replace {0} characters with '{1}'.</source>
+        <target state="new">Replace {0} characters with '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Nie można sformatować elementu „{0}”. Obecnie format obsługuje tylko projekty C# i Visual Basic.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Delete_0_characters">
+        <source>Delete {0} characters.</source>
+        <target state="new">Delete {0} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Determining_diagnostics">
         <source>Determining diagnostics...</source>
         <target state="translated">Trwa określanie diagnostyki...</target>
@@ -152,6 +157,11 @@
         <target state="translated">Uwzględnij wygenerowane pliki kodu w operacjach formatowania.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Insert_0">
+        <source>Insert '{0}'.</source>
+        <target state="new">Insert '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading_workspace">
         <source>Loading workspace.</source>
         <target state="translated">Ładowanie obszaru roboczego.</target>
@@ -170,6 +180,11 @@
       <trans-unit id="Project_0_is_using_configuration_from_1">
         <source>Project {0} is using configuration from '{1}'.</source>
         <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Replace_0_characters_with_1">
+        <source>Replace {0} characters with '{1}'.</source>
+        <target state="new">Replace {0} characters with '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Não foi possível formatar '{0}'. O formato atualmente suporta apenas projetos do Visual Basic e C#.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Delete_0_characters">
+        <source>Delete {0} characters.</source>
+        <target state="new">Delete {0} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Determining_diagnostics">
         <source>Determining diagnostics...</source>
         <target state="translated">Determinando os diagnósticos...</target>
@@ -152,6 +157,11 @@
         <target state="translated">Incluir arquivos de código gerados em operações de formatação.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Insert_0">
+        <source>Insert '{0}'.</source>
+        <target state="new">Insert '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading_workspace">
         <source>Loading workspace.</source>
         <target state="translated">Carregando espaço de trabalho.</target>
@@ -170,6 +180,11 @@
       <trans-unit id="Project_0_is_using_configuration_from_1">
         <source>Project {0} is using configuration from '{1}'.</source>
         <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Replace_0_characters_with_1">
+        <source>Replace {0} characters with '{1}'.</source>
+        <target state="new">Replace {0} characters with '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -72,6 +72,11 @@
         <target state="translated">Не удалось отформатировать "{0}". Форматирование сейчас поддерживается только для проектов C# и Visual Basic.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Delete_0_characters">
+        <source>Delete {0} characters.</source>
+        <target state="new">Delete {0} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Determining_diagnostics">
         <source>Determining diagnostics...</source>
         <target state="translated">Определение диагностики…</target>
@@ -152,6 +157,11 @@
         <target state="translated">Включить созданные файлы кода в операции форматирования.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Insert_0">
+        <source>Insert '{0}'.</source>
+        <target state="new">Insert '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading_workspace">
         <source>Loading workspace.</source>
         <target state="translated">Загрузка рабочей области.</target>
@@ -170,6 +180,11 @@
       <trans-unit id="Project_0_is_using_configuration_from_1">
         <source>Project {0} is using configuration from '{1}'.</source>
         <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Replace_0_characters_with_1">
+        <source>Replace {0} characters with '{1}'.</source>
+        <target state="new">Replace {0} characters with '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -72,6 +72,11 @@
         <target state="translated">'{0}' biçiminde değil. Biçimi şu anda yalnızca C# ve Visual Basic projeleri desteklemektedir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Delete_0_characters">
+        <source>Delete {0} characters.</source>
+        <target state="new">Delete {0} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Determining_diagnostics">
         <source>Determining diagnostics...</source>
         <target state="translated">Tanılama belirleniyor...</target>
@@ -152,6 +157,11 @@
         <target state="translated">Biçimlendirme işlemlerinde oluşturulan kod dosyalarını ekleyin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Insert_0">
+        <source>Insert '{0}'.</source>
+        <target state="new">Insert '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading_workspace">
         <source>Loading workspace.</source>
         <target state="translated">Çalışma alanı yükleniyor.</target>
@@ -170,6 +180,11 @@
       <trans-unit id="Project_0_is_using_configuration_from_1">
         <source>Project {0} is using configuration from '{1}'.</source>
         <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Replace_0_characters_with_1">
+        <source>Replace {0} characters with '{1}'.</source>
+        <target state="new">Replace {0} characters with '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -72,6 +72,11 @@
         <target state="translated">无法设置“{0}”的格式。该格式当前仅支持 C# 和 Visual Basic 项目。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Delete_0_characters">
+        <source>Delete {0} characters.</source>
+        <target state="new">Delete {0} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Determining_diagnostics">
         <source>Determining diagnostics...</source>
         <target state="translated">正在确定诊断…</target>
@@ -152,6 +157,11 @@
         <target state="translated">在格式化操作中包含所生成的代码文件。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Insert_0">
+        <source>Insert '{0}'.</source>
+        <target state="new">Insert '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading_workspace">
         <source>Loading workspace.</source>
         <target state="translated">正在加载工作区。</target>
@@ -170,6 +180,11 @@
       <trans-unit id="Project_0_is_using_configuration_from_1">
         <source>Project {0} is using configuration from '{1}'.</source>
         <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Replace_0_characters_with_1">
+        <source>Replace {0} characters with '{1}'.</source>
+        <target state="new">Replace {0} characters with '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -72,6 +72,11 @@
         <target state="translated">無法將 '{0}' 格式化。格式化目前只支援 C# 和 Visual Basic 專案。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Delete_0_characters">
+        <source>Delete {0} characters.</source>
+        <target state="new">Delete {0} characters.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Determining_diagnostics">
         <source>Determining diagnostics...</source>
         <target state="translated">正在判斷診斷...</target>
@@ -152,6 +157,11 @@
         <target state="translated">在格式化作業中包含產生的程式碼檔案。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Insert_0">
+        <source>Insert '{0}'.</source>
+        <target state="new">Insert '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Loading_workspace">
         <source>Loading workspace.</source>
         <target state="translated">正在載入工作區。</target>
@@ -170,6 +180,11 @@
       <trans-unit id="Project_0_is_using_configuration_from_1">
         <source>Project {0} is using configuration from '{1}'.</source>
         <target state="new">Project {0} is using configuration from '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Replace_0_characters_with_1">
+        <source>Replace {0} characters with '{1}'.</source>
+        <target state="new">Replace {0} characters with '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="Required_references_did_not_load_for_0_or_referenced_project_Run_dotnet_restore_prior_to_formatting">


### PR DESCRIPTION
Since we are unable to report which rules were broken when applying the Roslyn formatter, this PR converts each TextChange into a detailed message reporting what type of change was made.

Possible resolution for #789

*Example output:*
```console
The dotnet runtime version is '6.0.0-alpha.1.21064.11'.
Using MSBuild.exe located in '/usr/local/share/dotnet/sdk/6.0.100-alpha.1.21065.7/'.
Formatting code files in workspace '/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/unformatted_project.csproj'.
Loading workspace.
Project unformatted_project is using configuration from '/Users/joeyrobichaud/Source/format/.editorconfig'.
Project unformatted_project is using configuration from '/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/.editorconfig'.
Complete in 2167ms.
Determining formattable files.
Complete in 355ms.
Running formatters.
other_items/OtherClass.cs(5,3): Fix whitespace formatting. Delete 2 characters.
other_items/OtherClass.cs(6,3): Fix whitespace formatting. Delete 2 characters.
other_items/OtherClass.cs(7,5): Fix whitespace formatting. Delete 4 characters.
other_items/OtherClass.cs(8,5): Fix whitespace formatting. Delete 4 characters.
other_items/OtherClass.cs(9,7): Fix whitespace formatting. Delete 6 characters.
other_items/OtherClass.cs(10,5): Fix whitespace formatting. Delete 4 characters.
other_items/OtherClass.cs(11,3): Fix whitespace formatting. Delete 2 characters.
Program.cs(5,3): Fix whitespace formatting. Delete 2 characters.
Program.cs(6,3): Fix whitespace formatting. Delete 2 characters.
Program.cs(7,5): Fix whitespace formatting. Delete 4 characters.
Program.cs(8,5): Fix whitespace formatting. Delete 4 characters.
Program.cs(9,7): Fix whitespace formatting. Delete 6 characters.
Program.cs(10,5): Fix whitespace formatting. Delete 4 characters.
Program.cs(11,3): Fix whitespace formatting. Delete 2 characters.
other_items/OtherClass.cs(12,2): Fix final newline. Delete 1 characters.
Program.cs(12,2): Fix final newline. Delete 1 characters.
Complete in 544ms.
Formatted code file '/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/other_items/OtherClass.cs'.
Formatted code file '/Users/joeyrobichaud/Source/format/tests/projects/for_code_formatter/unformatted_project/Program.cs'.
Formatted 2 of 6 files.
Format complete in 3067ms.
```

Other types of messages:
`Insert '\s\s'.`
`Replace 4 characters with '\t\t'.`