### PR TITLE
Add main to yml trigger list

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -1,12 +1,14 @@
 # Branches that trigger a build on commit
 trigger:
 - master
+- main
 - feature/*
 - release/*
 
 # Branches that trigger builds on PR
 pr:
 - master
+- main
 - feature/*
 - release/*
 

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -12,6 +12,7 @@ variables:
 # Branches that trigger a build on commit
 trigger:
 - master
+- main
 
 stages:
 - stage: build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,12 +1,14 @@
 # Branches that trigger a build on commit
 trigger:
 - master
+- main
 - feature/*
 - release/*
 
 # Branches that trigger builds on PR
 pr:
 - master
+- main
 - feature/*
 - release/*
 


### PR DESCRIPTION
Adds main to yml trigger list while we switch from master -> main. Hopefully keeping master in the trigger list for now avoids the build breakage seen in the roslyn repo. Once the transition is complete, master will be removed from the list and I will fix up the rest of the references in the repo.