### PR TITLE
Use correct flag for codestyle codefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ### New in v5.0.211103
 
 ### New Features
-- Can now apply codestyle codefixes automatically with `dotnet format --fix-codestyle`
+- Can now apply codestyle codefixes automatically with `dotnet format --fix-style`
 - Can now apply analyzer codefixes automatically with `dotnet format --fix-analyzers`
 
 ### Breaking Changes


### PR DESCRIPTION
Found a small typo in the README that had me confused for a few minutes. Just wanted to fix it so this doesn't happen to the next developer checking out this awesome tool.

I believe the correct flag for codestyle fixes is `dotnet format --fix-style` not `dotnet format --fix-codestyle`.