### PR TITLE
Run CodeStyle formatter before removing unnecessary imports

### DIFF
--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -26,8 +26,8 @@ namespace Microsoft.CodeAnalysis.Tools
             new CharsetFormatter(),
             new OrganizeImportsFormatter(),
             AnalyzerFormatter.CodeStyleFormatter,
-            new UnnecessaryImportsFormatter(),
-            AnalyzerFormatter.ThirdPartyFormatter);
+            AnalyzerFormatter.ThirdPartyFormatter,
+            new UnnecessaryImportsFormatter());
 
         public static async Task<WorkspaceFormatResult> FormatWorkspaceAsync(
             FormatOptions formatOptions,

--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -25,8 +25,8 @@ namespace Microsoft.CodeAnalysis.Tools
             new EndOfLineFormatter(),
             new CharsetFormatter(),
             new OrganizeImportsFormatter(),
-            new UnnecessaryImportsFormatter(),
             AnalyzerFormatter.CodeStyleFormatter,
+            new UnnecessaryImportsFormatter(),
             AnalyzerFormatter.ThirdPartyFormatter);
 
         public static async Task<WorkspaceFormatResult> FormatWorkspaceAsync(


### PR DESCRIPTION
Resolves #1069

As pointed out, converting declarations to use `var` when fixing code style issues potentially creates unused imports.