### PR TITLE
Update devcontainer to build with NET 6 SDK

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,8 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
-ARG VARIANT="3.1-bionic"
-FROM mcr.microsoft.com/dotnet/core/sdk:${VARIANT}
+ARG VARIANT="3.1"
+FROM mcr.microsoft.com/dotnet/sdk:${VARIANT}-focal
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,8 +6,8 @@
     "dockerfile": "Dockerfile",
     "args": {
       // Update 'VARIANT' to pick a .NET Core version. Rebuild the container if
-      // it already exists to update. Example variants: 2.1-bionic, 3.1-bionic
-      "VARIANT": "3.1-bionic",
+      // it already exists to update. Example variants: 3.1, 5.0, 6.0
+      "VARIANT": "6.0",
       // Options
       "INSTALL_NODE": "false",
       "NODE_VERSION": "lts/*",


### PR DESCRIPTION
Noticed that format would not load within its devcontainer because OmniSharp couldn't see the locally restored NET 6 SDK.