### PR TITLE
Remove package references that were used avoid version conflicts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,10 +38,5 @@
     <PackageVersion Include="System.CommandLine.Rendering" Version="0.3.0-alpha.21256.1" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.21256.1" />
     <PackageVersion Include="System.Text.Json" Version="$(MicrosoftExtensionsVersion)" />
-
-    <!-- Avoid version conflicts during build. -->
-    <PackageVersion Include="System.Security.Cryptography.ProtectedData" Version="$(MicrosoftExtensionsVersion)"/>
-    <PackageVersion Include="System.Security.Principal.Windows" Version="$(MicrosoftExtensionsVersion)"/>
-    <PackageVersion Include="Microsoft.Win32.Registry" Version="$(MicrosoftExtensionsVersion)" />
   </ItemGroup>
 </Project>

--- a/src/dotnet-format.csproj
+++ b/src/dotnet-format.csproj
@@ -56,11 +56,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection"  />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing"  />
     <PackageReference Include="Microsoft.Extensions.Logging"  />
-
-    <!-- Avoid version conflicts during build. -->
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" />
-    <PackageReference Include="System.Security.Principal.Windows" />
-    <PackageReference Include="Microsoft.Win32.Registry" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
testing to see if these are still necessary.