### PR TITLE
Fix quoting glob/wildcard character in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Development builds of `dotnet-format` are being hosted on Azure Packages. You ca
 You can install the latest build of the tool using the following command.
 
 ```console
-dotnet tool install -g dotnet-format --version 6.0.* --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
+dotnet tool install -g dotnet-format --version "6.0.*" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
 ```
 
 ### How To Use


### PR DESCRIPTION
If the wildcard character is not quoted I get the following error:

```console
❯ dotnet tool install --local dotnet-format --version 6.0.* --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json
zsh: no matches found: 6.0.*
```

This change fixes that. 