### PR TITLE
Limit reported compiler diagnostics to those that support FixAllScope.Solution

### DIFF
--- a/src/Analyzers/AnalyzerFormatter.cs
+++ b/src/Analyzers/AnalyzerFormatter.cs
@@ -66,8 +66,9 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
 
             var allFixers = projectAnalyzersAndFixers.Values.SelectMany(analyzersAndFixers => analyzersAndFixers.Fixers).ToImmutableArray();
 
-            // Only include compiler diagnostics if we have a fixer that can fix them.
+            // Only include compiler diagnostics if we have an associated fixer that supports FixAllScope.Solution
             var fixableCompilerDiagnostics = allFixers
+                .Where(codefix => codefix.GetFixAllProvider()?.GetSupportedFixAllScopes()?.Contains(FixAllScope.Solution) == true)
                 .SelectMany(codefix => codefix.FixableDiagnosticIds.Where(id => id.StartsWith("CS") || id.StartsWith("BC")))
                 .ToImmutableHashSet();
 


### PR DESCRIPTION
There are times when dotnet-format reports compiler diagnostics when running Analyzers (See https://github.com/dotnet/format/issues/1061). This can be caused by missing unrestored dependencies but also by dotnet-format being unable to properly load the workspace. We had already limited the compiler diagnostics that we report to those that also have an related CodeFixProvider. This PR takes it a step further and filters out those that do not support FixAllScope.Solution.