### PR TITLE
Add local source-build infrastructure

### DIFF
--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,0 +1,8 @@
+<Project>
+
+  <PropertyGroup>
+    <GitHubRepositoryName>format</GitHubRepositoryName>
+    <SourceBuildManagedOnly>true</SourceBuildManagedOnly>
+  </PropertyGroup>
+
+</Project>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,0 +1,5 @@
+<UsageData>
+  <IgnorePatterns>
+    <UsagePattern IdentityGlob="*/*" />
+  </IgnorePatterns>
+</UsageData>


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/2509

This PR adds the infrastructure needed to include dotnet/format in source-build.  It is needed in source-build because the SDK references it.

See https://github.com/dotnet/source-build/blob/main/Documentation/planning/arcade-powered-source-build/onboarding/local-onboarding.md for additional details on this infra.