### PR TITLE
[release/6.x] Add source-build patches necessary to eliminate prebuilts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,6 @@
   <!-- <Import Project="eng\Versions.props" /> -->
 
   <PropertyGroup>
-    <MicrosoftBuildVersion>16.11.0</MicrosoftBuildVersion>
     <MicrosoftExtensionsVersion>5.0.0</MicrosoftExtensionsVersion>
     <!-- In order tests against the same version of NuGet as the SDK. We have to set this to match. -->
     <NuGetVersion>6.0.0-preview.4.221</NuGetVersion>
@@ -15,7 +14,7 @@
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.4.1" />
     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)"/>
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.1-beta1.21413.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(MicrosoftNETCoreCompilersPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftNETCoreCompilersPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftNETCoreCompilersPackageVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,6 +13,8 @@
     <AutoGenerateAssemblyVersion>true</AutoGenerateAssemblyVersion>
   </PropertyGroup>
   <PropertyGroup>
+    <MicrosoftBuildVersion>16.11.0</MicrosoftBuildVersion>
+    <MicrosoftCodeAnalysisAnalyzersVersion>3.3.2</MicrosoftCodeAnalysisAnalyzersVersion>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
     <MicrosoftNETCoreCompilersPackageVersion>4.0.0-6.21515.3</MicrosoftNETCoreCompilersPackageVersion>
     <!-- Dependencies from https://github.com/dotnet/command-line-api -->

--- a/perf/dotnet-format.Performance.csproj
+++ b/perf/dotnet-format.Performance.csproj
@@ -14,6 +14,7 @@
 
     <!-- Always run on the latest runtime installed. -->
     <RollForward>LatestMajor</RollForward>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />

--- a/src/dotnet-format.csproj
+++ b/src/dotnet-format.csproj
@@ -19,7 +19,6 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 
     <!-- Always run on the latest runtime installed. -->
-    <RuntimeFrameworkVersion>6.0.0-preview.7.21317.1</RuntimeFrameworkVersion>
     <RollForward>LatestMajor</RollForward>
 
     <IsPackable>true</IsPackable>
@@ -29,7 +28,7 @@
       These identifiers are for generating the shim'd core executables for signing. Not all options
       from $(RoslynPortableRuntimeIdentifiers) work or make sense in this context.
     -->
-    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
+    <PackAsToolShimRuntimeIdentifiers Condition=" '$(DotnetBuildFromSource)' != 'true' ">win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet-format.csproj
+++ b/src/dotnet-format.csproj
@@ -19,6 +19,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 
     <!-- Always run on the latest runtime installed. -->
+    <RuntimeFrameworkVersion Condition=" '$(DotnetBuildFromSource)' != 'true' ">6.0.0-preview.7.21317.1</RuntimeFrameworkVersion>
     <RollForward>LatestMajor</RollForward>
 
     <IsPackable>true</IsPackable>

--- a/tests/dotnet-format.UnitTests.csproj
+++ b/tests/dotnet-format.UnitTests.csproj
@@ -12,6 +12,7 @@
     <!-- Always run on the latest runtime installed. -->
     <RuntimeFrameworkVersion>6.0.0-preview.7.21317.1</RuntimeFrameworkVersion>
     <RollForward>LatestMajor</RollForward>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/2509.

These are the changes necessary to eliminate prebuilts from .NET source-build.

1. Exclude test and perf projects from source-build.
2. Move a couple version properties to the `eng/Versions.props` file so that the source-built versions get picked up.
3. dotnet-format project tweaks to eliminate hard coded framework version