### PR TITLE
[release/6.x] Fix pool for Publish To Build Asset Registry step

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -106,8 +106,8 @@ stages:
       publishUsingPipelines: true
       dependsOn:
         - OfficialBuild
-      queue:
-        name: Hosted VS2017
+      pool:
+        vmImage: windows-2019
 
 - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
   - template: eng\common\templates\post-build\post-build.yml


### PR DESCRIPTION
The parameter name is 'pool'. This has always been wrong (AzDO discards the non-matching parameter). It didn't matter until recently when the default pool was changed in the pipeline, which caused this step to try executing on a Unix machine.