### PR TITLE
Use windows latest and VS 2022 when building in CI.

### DIFF
--- a/azure-pipelines-integration.yml
+++ b/azure-pipelines-integration.yml
@@ -14,7 +14,7 @@ jobs:
 
 - job: Format
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-latest'
   strategy:
     maxParallel: 8
     matrix:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -17,7 +17,7 @@ stages:
 - stage: build
   displayName: Build and Test
   pool:
-    name: VSEngSS-MicroBuild2019-1ES
+    name: VSEngSS-MicroBuild2022-1ES
     demands:
     - cmd
 


### PR DESCRIPTION
Fixes build warnings from CI.

Test build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=5470339&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76 (microsoft)