### PR TITLE
Include SourceGeneratedDocuments when including generated files

### DIFF
--- a/src/Analyzers/Extensions.cs
+++ b/src/Analyzers/Extensions.cs
@@ -145,6 +145,11 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
 
                     continue;
                 }
+
+                if (descriptor.DefaultSeverity > severity)
+                {
+                    severity = descriptor.DefaultSeverity;
+                }
             }
 
             return severity;

--- a/src/CodeFormatter.cs
+++ b/src/CodeFormatter.cs
@@ -89,6 +89,10 @@ namespace Microsoft.CodeAnalysis.Tools
             foreach (var documentId in documentIdsWithErrors)
             {
                 var documentWithError = solution.GetDocument(documentId);
+                if (documentWithError is null)
+                {
+                    documentWithError = await solution.GetSourceGeneratedDocumentAsync(documentId, cancellationToken).ConfigureAwait(false);
+                }
 
                 logger.LogInformation(Resources.Formatted_code_file_0, documentWithError!.FilePath);
             }
@@ -176,6 +180,7 @@ namespace Microsoft.CodeAnalysis.Tools
 
             var documentsCoveredByEditorConfig = ImmutableArray.CreateBuilder<DocumentId>(totalFileCount);
             var documentsNotCoveredByEditorConfig = ImmutableArray.CreateBuilder<DocumentId>(totalFileCount);
+            var sourceGeneratedDocuments = ImmutableArray.CreateBuilder<DocumentId>(16);
 
             var addedFilePaths = new HashSet<string>(totalFileCount);
 
@@ -226,10 +231,16 @@ namespace Microsoft.CodeAnalysis.Tools
                         throw new Exception($"Unable to get a syntax tree for '{document.Name}'");
                     }
 
-                    if (!formatOptions.IncludeGeneratedFiles &&
-                        await GeneratedCodeUtilities.IsGeneratedCodeAsync(syntaxTree, cancellationToken).ConfigureAwait(false))
+                    if (await GeneratedCodeUtilities.IsGeneratedCodeAsync(syntaxTree, cancellationToken).ConfigureAwait(false))
                     {
-                        continue;
+                        if (!formatOptions.IncludeGeneratedFiles)
+                        {
+                            continue;
+                        }
+                        else
+                        {
+                            Debug.WriteLine($"Including generated file '{document.FilePath}'.");
+                        }
                     }
 
                     // Track files covered by an editorconfig separately from those not covered.
@@ -247,6 +258,16 @@ namespace Microsoft.CodeAnalysis.Tools
                         documentsNotCoveredByEditorConfig.Add(document.Id);
                     }
                 }
+
+                if (formatOptions.IncludeGeneratedFiles)
+                {
+                    var generatedDocuments = await project.GetSourceGeneratedDocumentsAsync(cancellationToken).ConfigureAwait(false);
+                    foreach (var generatedDocument in generatedDocuments)
+                    {
+                        Debug.WriteLine($"Including source generated file '{generatedDocument.FilePath}'.");
+                        sourceGeneratedDocuments.Add(generatedDocument.Id);
+                    }
+                }
             }
 
             // Initially we would format all documents in a workspace, even if some files weren't covered by an
@@ -257,9 +278,12 @@ namespace Microsoft.CodeAnalysis.Tools
 
             // If no files are covered by an editorconfig, then return them all. Otherwise only return
             // files that are covered by an editorconfig.
-            return documentsCoveredByEditorConfig.Count == 0
-                ? (projectFileCount, documentsNotCoveredByEditorConfig.ToImmutable())
-                : (projectFileCount, documentsCoveredByEditorConfig.ToImmutable());
+            var formattableDocuments = documentsCoveredByEditorConfig.Count == 0
+                ? documentsNotCoveredByEditorConfig
+                : documentsCoveredByEditorConfig;
+
+            formattableDocuments.AddRange(sourceGeneratedDocuments);
+            return (projectFileCount + sourceGeneratedDocuments.Count, formattableDocuments.ToImmutable());
         }
     }
 }


### PR DESCRIPTION
Source generated documents are not included in Project.Documents and have to be queried separately. Although it isn't typically useful to report issues for these documents, it can be helpful if they are generating part of your public API which is being tracked with the PublicApiAnalyzers.