### PR TITLE
Filter out project early if it doesn't have any formattable documents

### DIFF
--- a/src/Analyzers/AnalyzerFormatter.cs
+++ b/src/Analyzers/AnalyzerFormatter.cs
@@ -284,6 +284,13 @@ namespace Microsoft.CodeAnalysis.Tools.Analyzers
                     continue;
                 }
 
+                // Skip if the project does not contain any of the formattable paths.
+                if (!project.Documents.Any(d => d.FilePath is not null && formattablePaths.Contains(d.FilePath)))
+                {
+                    projectAnalyzers.Add(projectId, ImmutableArray<DiagnosticAnalyzer>.Empty);
+                    continue;
+                }
+
                 var analyzers = ImmutableArray.CreateBuilder<DiagnosticAnalyzer>();
 
                 // Filter analyzers by project's language


### PR DESCRIPTION
Improves the runtime in large solutions when a small number of files is included (`--include`). This is a common use-case for developers to lint/format only modified files in their branch.

In a solution with about 80 projects, this improves the runtime by about 50% when `--include SomeProject/SomeFile.cs` is specified.

Related issues: https://github.com/dotnet/format/issues/1378 and https://github.com/dotnet/format/issues/757