### PR TITLE
Remove unnecessary config

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,11 +6,6 @@
 
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.Arcade.Sdk" />
 
-  <PropertyGroup>
-    <!-- Disable until they are better supported in tooling. -->
-    <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
-  </PropertyGroup>
-
   <!-- Nuget settings -->
   <PropertyGroup>
     <!-- Use Directory.Packages.props for nuget package versions -->


### PR DESCRIPTION
This config works only for .NET 6 preview 7, since .NET 6 RC 1 `ImplicitUsings` is used and disabled by default