### PR TITLE
Copy fix: agrument should be argument

### DIFF
--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -124,7 +124,7 @@
     <value>The solution file '{0}' does not exist.</value>
   </data>
   <data name="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_argument" xml:space="preserve">
-    <value>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; agrument.</value>
+    <value>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</value>
   </data>
   <data name="Could_not_find_a_MSBuild_project_or_solution_file_in_0_Specify_which_to_use_with_the_workspace_argument" xml:space="preserve">
     <value>Could not find a MSBuild project file or solution file in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</value>

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -48,7 +48,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_argument">
-        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; agrument.</source>
+        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">{0} obsahuje jak soubor projektu MSBuild, tak soubor řešení. Určete, který soubor chcete použít, pomocí argumentu &lt;workspace&gt;.</target>
         <note />
       </trans-unit>

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -48,7 +48,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_argument">
-        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; agrument.</source>
+        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">In "{0}" wurden eine MSBuild-Projektdatei und eine Projektmappendatei gefunden. Geben Sie die zu verwendende Datei mit dem &lt;workspace&gt;-Argument an.</target>
         <note />
       </trans-unit>

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -48,7 +48,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_argument">
-        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; agrument.</source>
+        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">Se encontró un archivo del proyecto y un archivo de solución MSBuild en "{0}". Especifique cuál debe usarse con el argumento &lt;workspace&gt;.</target>
         <note />
       </trans-unit>

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -48,7 +48,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_argument">
-        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; agrument.</source>
+        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">Fichier projet et fichier solution MSBuild trouvés dans '{0}'. Spécifiez celui qui doit être utilisé avec l'argument &lt;espace de travail&gt;.</target>
         <note />
       </trans-unit>

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -48,7 +48,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_argument">
-        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; agrument.</source>
+        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">In '{0}' sono stati trovati sia un file di progetto che un file di soluzione MSBuild. Per specificare quello desiderato, usare l'argomento &lt;workspace&gt;.</target>
         <note />
       </trans-unit>

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -48,7 +48,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_argument">
-        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; agrument.</source>
+        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">MSBuild のプロジェクト ファイルとソリューション ファイルの両方が '{0}' で見つかりました。使用するものを &lt;workspace&gt; 引数で指定してください。</target>
         <note />
       </trans-unit>

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -48,7 +48,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_argument">
-        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; agrument.</source>
+        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">'{0}'에 MSBuild 프로젝트 파일 및 솔루션 파일이 모두 있습니다. &lt;workspace&gt; 인수를 사용하여 사용할 파일을 지정하세요.</target>
         <note />
       </trans-unit>

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -48,7 +48,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_argument">
-        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; agrument.</source>
+        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">W elemencie „{0}” znaleziono zarówno plik rozwiązania, jak i plik projektu MSBuild. Określ plik do użycia za pomocą argumentu &lt;workspace&gt;.</target>
         <note />
       </trans-unit>

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -48,7 +48,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_argument">
-        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; agrument.</source>
+        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">Foram encontrados um arquivo de solução e um arquivo de projeto do MSBuild em '{0}'. Especifique qual será usado com o argumento &lt;workspace&gt;.</target>
         <note />
       </trans-unit>

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -48,7 +48,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_argument">
-        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; agrument.</source>
+        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">В "{0}" обнаружены как файл проекта, так и файл решения MSBuild. Укажите используемый файл с помощью аргумента &lt;workspace&gt;.</target>
         <note />
       </trans-unit>

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -48,7 +48,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_argument">
-        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; agrument.</source>
+        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">'{0}' içinde hem MSBuild proje dosyası hem de çözüm dosyası bulundu. Hangisinin &lt;çalışma alanı&gt; bağımsız değişkeni ile kullanılacağını belirtin.</target>
         <note />
       </trans-unit>

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -48,7 +48,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_argument">
-        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; agrument.</source>
+        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">在“{0}”中同时找到 MSBuild 项目文件和解决方案文件。请指定要用于 &lt;workspace&gt; 参数的文件。</target>
         <note />
       </trans-unit>

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -48,7 +48,7 @@
         <note />
       </trans-unit>
       <trans-unit id="Both_a_MSBuild_project_file_and_solution_file_found_in_0_Specify_which_to_use_with_the_workspace_argument">
-        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; agrument.</source>
+        <source>Both a MSBuild project file and solution file found in '{0}'. Specify which to use with the &lt;workspace&gt; argument.</source>
         <target state="translated">在 '{0}' 中同時找到 MSBuild 專案檔與解決方案檔。請指定要用於 &lt;workspace&gt; 引數的檔案。</target>
         <note />
       </trans-unit>


### PR DESCRIPTION
Running `dotnet format` just now found a typo:

![image](https://user-images.githubusercontent.com/18598/167014233-30e3515c-8708-4a5b-8440-4e2f929e47ef.png)
