### PR TITLE
[release/7.x] Update MS.Extensions.DependencyInjection version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,7 +15,7 @@
   <PropertyGroup>
     <MicrosoftBuildVersion>17.3.0-preview-22302-02</MicrosoftBuildVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>3.3.3</MicrosoftCodeAnalysisAnalyzersVersion>
-    <MicrosoftExtensionsDependencyInjectionVersion>7.0.0-preview.2.22152.2</MicrosoftExtensionsDependencyInjectionVersion>
+    <MicrosoftExtensionsDependencyInjectionVersion>7.0.0-rc.1.22426.10</MicrosoftExtensionsDependencyInjectionVersion>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
     <MicrosoftNetCompilersToolsetPackageVersion>4.4.0-3.22431.2</MicrosoftNetCompilersToolsetPackageVersion>
     <!-- Dependencies from https://github.com/dotnet/command-line-api -->

--- a/src/Logging/SimpleConsoleLogger.cs
+++ b/src/Logging/SimpleConsoleLogger.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Tools.Logging
             return (int)logLevel >= (int)_minimalLogLevel;
         }
 
-        public IDisposable BeginScope<TState>(TState state)
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull
         {
             return NullScope.Instance;
         }


### PR DESCRIPTION
See https://github.com/dotnet/format/issues/1609

It looks like this was automatically updated via an arcade dependency flow, but I'm not certain that I should trigger that manually so I'm trying to update Microsoft.Extensions.DependencyInjection by hand here.