### PR TITLE
Unit test fixes for Windows

### DIFF
--- a/tests/Analyzers/ThirdPartyAnalyzerFormatterTests.cs
+++ b/tests/Analyzers/ThirdPartyAnalyzerFormatterTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -86,21 +87,26 @@ class C
 
         int count = 5;
 
+
+        count = 6;
+
     }
 
 }
 ";
 
-            var expectedCode = @"
+            // Hack for Windows: StyleCop uses the Environment NewLine for its replacement,
+            // so we have take care of it
+            var expectedCode = @$"
 class C
-{
+{{
     void M()
-    {
+    {{
         object obj = new object();
-
-        int count = 5;
-    }
-}
+{Environment.NewLine}        int count = 5;
+{Environment.NewLine}        count = 6;
+    }}
+}}
 ";
 
             var editorConfig = new Dictionary<string, string>()
@@ -163,6 +169,9 @@ class C
 
                 // Prefer using. IDISP017
                 ["dotnet_diagnostic.IDISP017.severity"] = "error",
+
+                // We expect new line as end_of_line in this test
+                ["end_of_line"] = EndOfLineFormatter.GetEndOfLineOption("\n"),
             };
 
             await AssertCodeChangedAsync(testCode, expectedCode, editorConfig, fixCategory: FixCategory.Analyzers, analyzerReferences: analyzerReferences);
@@ -210,6 +219,9 @@ class C
 
                 // Prefer using. IDISP017
                 ["dotnet_diagnostic.IDISP017.severity"] = "error",
+
+                // We expect new line as end_of_line in this test
+                ["end_of_line"] = EndOfLineFormatter.GetEndOfLineOption("\n"),
             };
 
             await AssertCodeChangedAsync(testCode, expectedCode, editorConfig, fixCategory: FixCategory.Analyzers, analyzerReferences: analyzerReferences);

--- a/tests/CodeFormatterTests.cs
+++ b/tests/CodeFormatterTests.cs
@@ -587,9 +587,13 @@ namespace Microsoft.CodeAnalysis.Tools.Tests
         [MSBuildFact]
         public async Task GeneratorSolution_AdditionalDocumentsUpdated_WhenIncludingGenerated()
         {
-            const string ExpectedPublicApi = @"Greeter
-Greeter.Greet() -> void
-Greeter.Greeter() -> void";
+            var sb = new System.Text.StringBuilder();
+            sb.Append("Greeter");
+            sb.Append(Environment.NewLine);
+            sb.Append("Greeter.Greet() -> void");
+            sb.Append(Environment.NewLine);
+            sb.Append("Greeter.Greeter() -> void");
+            var expectedPublicApi = sb.ToString();
 
             // Copy solution to temp folder so we can write changes to disk.
             var solutionPath = CopyToTempFolder(s_generatorSolutionPath);
@@ -617,7 +621,7 @@ Greeter.Greeter() -> void";
 
                 // Verify that changes were persisted to disk.
                 var unshippedPublicApi = File.ReadAllText(Path.Combine(solutionPath, "console_app", "PublicAPI.Unshipped.txt"));
-                Assert.Equal(ExpectedPublicApi, unshippedPublicApi);
+                Assert.Equal(expectedPublicApi, unshippedPublicApi);
             }
             finally
             {

--- a/tests/Formatters/OrganizeImportsFormatterTests.cs
+++ b/tests/Formatters/OrganizeImportsFormatterTests.cs
@@ -41,7 +41,7 @@ class C
 
             var editorConfig = new Dictionary<string, string>()
             {
-                ["end_of_line"] = EndOfLineFormatter.GetEndOfLineOption(Environment.NewLine),
+                ["end_of_line"] = EndOfLineFormatter.GetEndOfLineOption("\n"),
                 ["dotnet_sort_system_directives_first"] = "false",
                 ["dotnet_separate_import_directive_groups"] = "false"
             };
@@ -72,7 +72,7 @@ class C
 
             var editorConfig = new Dictionary<string, string>()
             {
-                ["end_of_line"] = EndOfLineFormatter.GetEndOfLineOption(Environment.NewLine),
+                ["end_of_line"] = EndOfLineFormatter.GetEndOfLineOption("\n"),
                 ["dotnet_sort_system_directives_first"] = "true",
                 ["dotnet_separate_import_directive_groups"] = "false"
             };
@@ -104,7 +104,7 @@ class C
 
             var editorConfig = new Dictionary<string, string>()
             {
-                ["end_of_line"] = EndOfLineFormatter.GetEndOfLineOption(Environment.NewLine),
+                ["end_of_line"] = EndOfLineFormatter.GetEndOfLineOption("\n"),
                 ["dotnet_sort_system_directives_first"] = "false",
                 ["dotnet_separate_import_directive_groups"] = "true"
             };
@@ -136,7 +136,7 @@ class C
 
             var editorConfig = new Dictionary<string, string>()
             {
-                ["end_of_line"] = EndOfLineFormatter.GetEndOfLineOption(Environment.NewLine),
+                ["end_of_line"] = EndOfLineFormatter.GetEndOfLineOption("\n"),
                 ["dotnet_sort_system_directives_first"] = "true",
                 ["dotnet_separate_import_directive_groups"] = "true"
             };
@@ -158,7 +158,7 @@ class C
 
             var editorConfig = new Dictionary<string, string>()
             {
-                ["end_of_line"] = EndOfLineFormatter.GetEndOfLineOption(Environment.NewLine)
+                ["end_of_line"] = EndOfLineFormatter.GetEndOfLineOption("\n")
             };
 
             await AssertCodeUnchangedAsync(code, editorConfig);


### PR DESCRIPTION
I've made some changes to the unit tests, so that they are all working with windows.
Almost all changes regarded the end-of-line problem between Windows and Linux/Mac.