### PR TITLE
When loading a project, use metadata references when possible.

### DIFF
--- a/src/Workspaces/MSBuildWorkspaceLoader.cs
+++ b/src/Workspaces/MSBuildWorkspaceLoader.cs
@@ -51,6 +51,9 @@ namespace Microsoft.CodeAnalysis.Tools.Workspaces
             {
                 try
                 {
+                    // In the case of loading a specific project, we don't want to load referenced projects, which is very time consuming, when there is already
+                    // a build on disk we can pull metadata from.
+                    workspace.LoadMetadataForReferencedProjects = true;
                     await workspace.OpenProjectAsync(solutionOrProjectPath, msbuildLogger: binlog, cancellationToken: cancellationToken).ConfigureAwait(false);
                 }
                 catch (InvalidOperationException)


### PR DESCRIPTION
This will not help CI cases where a build has not already been performed. It could significantly speed up project loading on developer machines when they already have a build of referenced projects.

Could help in situations like https://github.com/dotnet/format/issues/1378#issuecomment-1523117354