### PR TITLE
Fix format issues in 7.0.3xx SDK

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -14,10 +14,10 @@
   </PropertyGroup>
   <PropertyGroup>
     <MicrosoftBuildVersion>17.3.0-preview-22302-02</MicrosoftBuildVersion>
-    <MicrosoftCodeAnalysisAnalyzersVersion>3.3.3</MicrosoftCodeAnalysisAnalyzersVersion>
+    <MicrosoftCodeAnalysisAnalyzersVersion>3.3.4</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftExtensionsDependencyInjectionVersion>7.0.0-rc.1.22426.10</MicrosoftExtensionsDependencyInjectionVersion>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
-    <MicrosoftNetCompilersToolsetPackageVersion>4.5.0-2.22580.13</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>4.6.0</MicrosoftNetCompilersToolsetPackageVersion>
     <!-- Dependencies from https://github.com/dotnet/command-line-api -->
     <SystemCommandLineVersion>2.0.0-beta4.22504.1</SystemCommandLineVersion>
     <SystemCommandLineRenderingVersion>0.4.0-alpha.22504.1</SystemCommandLineRenderingVersion>


### PR DESCRIPTION
The repository references the 4.5.0 version of Roslyn and that is what gets loaded into the default `AssemblyLoadContext`. The analyzers in the 7.0.3xx SDK reference the 4.6.0 version of Roslyn. This breaks down
  because there is only one `AssemblyLoadContext` in play here and 4.5.0
  versions are already loaded. Moving to 4.6.0 to unblock the 7.0.3xx
  scenarios.

Related https://github.com/dotnet/sdk/issues/32598