### PR TITLE
Simplify the benchmarks

### DIFF
--- a/perf/FormattedFiles.cs
+++ b/perf/FormattedFiles.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Immutable;
 
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
 
 using Microsoft.CodeAnalysis.Tools.Utilities;
 using Microsoft.Extensions.Logging;

--- a/perf/FormattedFiles.cs
+++ b/perf/FormattedFiles.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools.Perf.Micro
 {
-    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     public class FormattedFiles
     {
         private const string UnformattedProjectPath = "tests/projects/for_code_formatter/unformatted_project/";

--- a/perf/NoFilesFormatted.cs
+++ b/perf/NoFilesFormatted.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Immutable;
 
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
 
 using Microsoft.CodeAnalysis.Tools.Utilities;
 using Microsoft.Extensions.Logging;

--- a/perf/NoFilesFormatted.cs
+++ b/perf/NoFilesFormatted.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Tools.Perf
 {
-    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     public class NoFilesFormatted
     {
         private const string FormattedProjectPath = "tests/projects/for_code_formatter/formatted_project/";

--- a/perf/RealWorldSolution.cs
+++ b/perf/RealWorldSolution.cs
@@ -82,8 +82,6 @@ namespace Microsoft.CodeAnalysis.Tools.Perf.Real
             public RealWorldConfig()
             {
                 var job = Job.Dry
-                    .WithPlatform(BenchmarkDotNet.Environments.Platform.X64)
-                    .WithRuntime(CoreRuntime.Core21)
                     .WithWarmupCount(1)
                     .WithIterationCount(12)
                     .WithOutlierMode(Perfolizer.Mathematics.OutlierDetection.OutlierMode.RemoveAll);

--- a/perf/RealWorldSolution.cs
+++ b/perf/RealWorldSolution.cs
@@ -6,7 +6,6 @@ using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Environments;
-using BenchmarkDotNet.Jobs;
 using Microsoft.CodeAnalysis.Tools.Utilities;
 using Microsoft.Extensions.Logging;
 

--- a/perf/RealWorldSolution.cs
+++ b/perf/RealWorldSolution.cs
@@ -5,7 +5,7 @@ using System.Collections.Immutable;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
-using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Jobs;
 using Microsoft.CodeAnalysis.Tools.Utilities;
 using Microsoft.Extensions.Logging;
 


### PR DESCRIPTION
There is no need to tell BenchmarkDotNet the target TFM of the benchmark process, as it by default uses the host process tfm.

https://benchmarkdotnet.org/articles/configs/toolchains.html#multiple-frameworks-support

Moreover the values got outdated:

https://github.com/dotnet/format/blob/1297f6fcff6c301c2617930bbbea8879cafee538/perf/dotnet-format.Performance.csproj#L4