### PR TITLE
Add explicit System.Text.Json dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,5 +36,6 @@
     <PackageVersion Include="NuGet.Versioning" Version="$(NuGetVersion)" />
     <PackageVersion Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageVersion Include="System.CommandLine.Rendering" Version="$(SystemCommandLineRenderingVersion)" />
+    <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonVersion)" />
   </ItemGroup>
 </Project>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -13,6 +13,10 @@
       <Uri>https://github.com/dotnet/command-line-api</Uri>
       <Sha>82273cb56c83b589e8e5b63da0ac9745ffc6e105</Sha>
     </Dependency>
+    <Dependency Name="System.Text.Json" Version="6.0.8">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>3241df7f2b0f3e2dada8d07229723c79fdbe4991</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="7.0.0-beta.21524.1">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -20,6 +20,8 @@
     <!-- Dependencies from https://github.com/dotnet/command-line-api -->
     <SystemCommandLineVersion>2.0.0-beta1.21473.1</SystemCommandLineVersion>
     <SystemCommandLineRenderingVersion>0.3.0-alpha.21473.1</SystemCommandLineRenderingVersion>
+    <!-- Dependencies from https://github.com/dotnet/runtime -->
+    <SystemTextJsonVersion>6.0.8</SystemTextJsonVersion>
   </PropertyGroup>
   <!--
     Other Dependency versions

--- a/src/dotnet-format.csproj
+++ b/src/dotnet-format.csproj
@@ -54,6 +54,12 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
+
+    <!--
+      Explicit System.Text.Json package reference is required for source-build to pick up the live package.
+      Avoids picking up an old version via transitive dependency from Microsoft.Build or Microsoft.CodeAnalysis.Workspaces.MSBuild.
+    -->
+    <PackageReference Include="System.Text.Json"  Condition=" '$(DotnetBuildFromSource)' == 'true'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/source-build/issues/3540

In source-build, `Microsoft.Build` package dependency is pulling a transitive `System.Text.Json` dependency from PSB. The fix is to simply add an explicit `System.Text.Json` dependency.

I'm not 100% sure if changes in `eng/Version.Details.xml` are necessary.