### PR TITLE
Revert "[main] Update dependencies from dotnet/command-line-api"

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -34,18 +34,18 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>60b77a63df30362ed1c66a834fcb8f8956ea113b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.440701">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.command-line-api" Version="0.1.430701">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>a045dd54a4c44723c215d992288160eb1401bb7f</Sha>
+      <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
       <SourceBuild RepoName="command-line-api" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="System.CommandLine" Version="2.0.0-beta4.23407.1">
+    <Dependency Name="System.CommandLine" Version="2.0.0-beta4.23307.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>a045dd54a4c44723c215d992288160eb1401bb7f</Sha>
+      <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
     </Dependency>
-    <Dependency Name="System.CommandLine.Rendering" Version="0.4.0-alpha.23407.1">
+    <Dependency Name="System.CommandLine.Rendering" Version="0.4.0-alpha.23307.1">
       <Uri>https://github.com/dotnet/command-line-api</Uri>
-      <Sha>a045dd54a4c44723c215d992288160eb1401bb7f</Sha>
+      <Sha>02fe27cd6a9b001c8feb7938e6ef4b3799745759</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,8 +17,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- command-line-api -->
-    <SystemCommandLineVersion>2.0.0-beta4.23407.1</SystemCommandLineVersion>
-    <SystemCommandLineRenderingVersion>0.4.0-alpha.23407.1</SystemCommandLineRenderingVersion>
+    <SystemCommandLineVersion>2.0.0-beta4.23307.1</SystemCommandLineVersion>
+    <SystemCommandLineRenderingVersion>0.4.0-alpha.23307.1</SystemCommandLineRenderingVersion>
     <!-- corefx -->
     <MicrosoftVisualBasicVersion>10.3.0</MicrosoftVisualBasicVersion>
     <!-- msbuild -->

--- a/src/Commands/FormatAnalyzersCommand.cs
+++ b/src/Commands/FormatAnalyzersCommand.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Immutable;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,8 +27,10 @@ namespace Microsoft.CodeAnalysis.Tools.Commands
             return command;
         }
 
-        private class FormatAnalyzersHandler : AsynchronousCliAction
+        private class FormatAnalyzersHandler : CliAction
         {
+            public override int Invoke(ParseResult parseResult) => InvokeAsync(parseResult, CancellationToken.None).GetAwaiter().GetResult();
+
             public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken)
             {
                 var formatOptions = parseResult.ParseVerbosityOption(FormatOptions.Instance);

--- a/src/Commands/FormatStyleCommand.cs
+++ b/src/Commands/FormatStyleCommand.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Immutable;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,8 +27,10 @@ namespace Microsoft.CodeAnalysis.Tools.Commands
             return command;
         }
 
-        private class FormatStyleHandler : AsynchronousCliAction
+        private class FormatStyleHandler : CliAction
         {
+            public override int Invoke(ParseResult parseResult) => InvokeAsync(parseResult, CancellationToken.None).GetAwaiter().GetResult();
+
             public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken)
             {
                 var formatOptions = parseResult.ParseVerbosityOption(FormatOptions.Instance);

--- a/src/Commands/FormatWhitespaceCommand.cs
+++ b/src/Commands/FormatWhitespaceCommand.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.CommandLine.Parsing;
 using System.Threading;
@@ -63,8 +62,10 @@ namespace Microsoft.CodeAnalysis.Tools.Commands
             }
         }
 
-        private class FormatWhitespaceHandler : AsynchronousCliAction
+        private class FormatWhitespaceHandler : CliAction
         {
+            public override int Invoke(ParseResult parseResult) => InvokeAsync(parseResult, CancellationToken.None).GetAwaiter().GetResult();
+
             public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken)
             {
                 var formatOptions = parseResult.ParseVerbosityOption(FormatOptions.Instance);

--- a/src/Commands/RootFormatCommand.cs
+++ b/src/Commands/RootFormatCommand.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Immutable;
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.CommandLine.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -31,8 +30,10 @@ namespace Microsoft.CodeAnalysis.Tools.Commands
             return formatCommand;
         }
 
-        private class FormatCommandDefaultHandler : AsynchronousCliAction
+        private class FormatCommandDefaultHandler : CliAction
         {
+            public override int Invoke(ParseResult parseResult) => InvokeAsync(parseResult, CancellationToken.None).GetAwaiter().GetResult();
+
             public override async Task<int> InvokeAsync(ParseResult parseResult, CancellationToken cancellationToken)
             {
                 var formatOptions = parseResult.ParseVerbosityOption(FormatOptions.Instance);


### PR DESCRIPTION
Reverts https://github.com/dotnet/format/pull/1920 in release/8.x to unblock https://github.com/dotnet/installer/pull/17576.