### PR TITLE
Fix source build poison leak of Microsoft.Bcl.AsyncInterfaces

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet.Annotations" Version="$(BenchmarkDotNetAnnotationsVersion)" />
     <PackageVersion Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="$(MicrosoftBclAsyncInterfacesVersion)" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorVersion)" />
     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)"/>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0-rtm.23513.17">
+    <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0-rtm.23517.16">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>60b77a63df30362ed1c66a834fcb8f8956ea113b</Sha>
+      <Sha>6f7af556d2761b0c93299cb88c61e4b747d6176a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis" Version="4.8.0-3.23474.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
+    <Dependency Name="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0-rtm.23513.17">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>60b77a63df30362ed1c66a834fcb8f8956ea113b</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis" Version="4.8.0-3.23474.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>232f7afa4966411958759c880de3a1765bdb28a0</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,6 +33,7 @@
     <!-- roslyn-sdk -->
     <MicrosoftCodeAnalysisAnalyzerTestingVersion>1.1.2-beta1.22216.1</MicrosoftCodeAnalysisAnalyzerTestingVersion>
     <!-- runtime -->
+    <MicrosoftBclAsyncInterfacesVersion>8.0.0-rtm.23517.16</MicrosoftBclAsyncInterfacesVersion>
     <MicrosoftExtensionsFileSystemGlobbingVersion>8.0.0-rtm.23517.16</MicrosoftExtensionsFileSystemGlobbingVersion>
     <MicrosoftExtensionsLoggingVersion>8.0.0-rtm.23517.16</MicrosoftExtensionsLoggingVersion>
     <!-- symreader -->

--- a/src/dotnet-format.csproj
+++ b/src/dotnet-format.csproj
@@ -45,10 +45,6 @@
 
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="System.CommandLine.Rendering" />
-
-    <!-- Bump the transitive DiaSymReader/1.4.0 dependency which is brought in by the ".Features" packages.
-         Using that verion is undesirable as it brings in the entire .NET Standard 1.x dependency graph. -->
-    <PackageReference Include="Microsoft.DiaSymReader" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet-format.csproj
+++ b/src/dotnet-format.csproj
@@ -26,6 +26,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Transitive dependency of Microsoft.CodeAnalysis.Workspaces.MSBuild. Need to explicitly provide a reference here to ensure
+         we can get the live version from source build rather than the 7.0.0 version from the transitive reference which leads to
+         a poison leak from source build reference packages. -->
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+
     <PackageReference Include="Microsoft.Build" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Locator" />

--- a/src/dotnet-format.csproj
+++ b/src/dotnet-format.csproj
@@ -26,11 +26,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Transitive dependency of Microsoft.CodeAnalysis.Workspaces.MSBuild. Need to explicitly provide a reference here to ensure
-         we can get the live version from source build rather than the 7.0.0 version from the transitive reference which leads to
-         a poison leak from source build reference packages. -->
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
-
     <PackageReference Include="Microsoft.Build" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Locator" />

--- a/tests/dotnet-format.UnitTests.csproj
+++ b/tests/dotnet-format.UnitTests.csproj
@@ -23,12 +23,6 @@
     <PackageReference Include="NuGet.Packaging" />
     <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="NuGet.Versioning" />
-
-    <!-- Bump the transitive dependencies which are brought in by "Microsoft.CodeAnalysis.Analyzer.Testing".
-         Using the referenced versions is undesirable as it brings in the entire .NET Standard 1.x dependency graph. -->
-    <PackageReference Include="Microsoft.VisualBasic" />
-    <PackageReference Include="NETStandard.Library" />
-    <PackageReference Include="Microsoft.VisualStudio.Composition" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/3670

This fixes a source build poison leak of Microsoft.Bcl.AsyncInterfaces that comes from this repo. This means the 7.0.0 version of Microsoft.Bcl.AsyncInterfaces defined in https://github.com/dotnet/source-build-reference-packages (SBRP) is leaking into the SDK that is produced by source build. That is a reference assembly and it shouldn't be leaked into the SDK output.

This is caused by a transitive dependency from Microsoft.CodeAnalysis.Workspaces.MSBuild.4.8.0-3.23510.8 to Microsoft.Bcl.AsyncInterfaces.7.0.0. So when loading Microsoft.CodeAnalysis.Workspaces.MSBuild, it also ends up loading Microsoft.Bcl.AsyncInterfaces from the SBRP nuget path.

To fix this, I've added an explicit reference to Microsoft.Bcl.AsyncInterfaces to ensure it uses the latest version, overriding the older version from the transitive dependency.