### PR TITLE
Add dotnet9 feeds

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -7,6 +7,8 @@
     <add key="dotnet-libraries-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-libraries-transport/nuget/v3/index.json" />
     <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="dotnet8-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8-transport/nuget/v3/index.json" />
+    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
+    <add key="dotnet9-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9-transport/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
   </packageSources>
@@ -24,6 +26,12 @@
       <package pattern="Microsoft.*" />
     </packageSource>
     <packageSource key="dotnet-libraries-transport">
+      <package pattern="Microsoft.*" />
+    </packageSource>
+    <packageSource key="dotnet9">
+      <package pattern="Microsoft.*" />
+    </packageSource>
+    <packageSource key="dotnet9-transport">
       <package pattern="Microsoft.*" />
     </packageSource>
     <packageSource key="dotnet8">


### PR DESCRIPTION
These are missing after the switch to 9.0, it is clear in https://github.com/dotnet/format/pull/1976 where there is actual flow from the .NET 9 channel,