### PR TITLE
Update VS version used for signed builds

### DIFF
--- a/global.json
+++ b/global.json
@@ -7,9 +7,9 @@
   "tools": {
     "dotnet": "8.0.100-rc.1.23463.5",
     "vs": {
-      "version": "17.6.0"
+      "version": "17.7.2"
     },
-    "xcopy-msbuild": "17.6.0-2"
+    "xcopy-msbuild": "17.7.2-1"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.23516.5"


### PR DESCRIPTION
Fixes [signed builds](https://dev.azure.com/devdiv/DevDiv/_build?definitionId=10913&_a=summary) broken since [arcade update](https://github.com/dotnet/format/pull/1962).

Tried running a signed build on this commit and it's now succeeding: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=8569345&view=results