### PR TITLE
Include external access layer for Razor

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,6 +24,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftNetCompilersToolsetPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(MicrosoftNetCompilersToolsetPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(MicrosoftNetCompilersToolsetPackageVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler" Version="$(MicrosoftNetCompilersToolsetPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />

--- a/src/dotnet-format.csproj
+++ b/src/dotnet-format.csproj
@@ -51,6 +51,9 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
 
+    <!-- Included with Microsoft.CodeAnalysis.dll for Razor support -->
+    <PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler" ExcludeAssets="compile" />
+
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="Microsoft.Extensions.Logging" />


### PR DESCRIPTION
This assembly must be provided by the host (alongside Microsoft.CodeAnalysis.dll) for Razor to be supported.

@JoeRobich @jjonescz this fixes tests failing with the following message:

```
  Failed Microsoft.CodeAnalysis.Tools.Tests.MSBuild.MSBuildWorkspaceLoaderTests.CSharpTemplateProject_LoadWithNoDiagnostics(templateName: "web") [4 s]
  Error Message:
   System.MissingMethodException : Method not found: 'System.Collections.Generic.IEnumerator`1<Microsoft.CodeAnalysis.NodeStateEntry`1<System.ValueTuple`2<System.__Canon,System.__Canon>>> Microsoft.CodeAnalysis.NodeStateTable`1.GetEnumerator()'.
  Stack Trace:
     at Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler.HostOutputNode`1.AppendOutputs(IncrementalExecutionContext context, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.GeneratorDriver.UpdateOutputs(ImmutableArray`1 outputNodes, IncrementalGeneratorOutputKind outputKind, Builder generatorRunStateBuilder, CancellationToken cancellationToken, Builder driverStateBuilder)
   at Microsoft.CodeAnalysis.GeneratorDriver.RunGeneratorsCore(Compilation compilation, DiagnosticBag diagnosticsBag, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.GeneratorDriver.RunGenerators(Compilation compilation, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.ComputeNewGeneratorInfoInCurrentProcessAsync(SolutionState solution, Compilation compilationWithoutGeneratedFiles, CompilationTrackerGeneratorInfo generatorInfo, Compilation compilationWithStaleGeneratedTrees, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.ComputeNewGeneratorInfoAsync(SolutionState solution, Compilation compilationWithoutGeneratedFiles, CompilationTrackerGeneratorInfo generatorInfo, Compilation compilationWithStaleGeneratedTrees, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.AddExistingOrComputeNewGeneratorInfoAsync(SolutionState solution, Compilation compilationWithoutGeneratedFiles, CompilationTrackerGeneratorInfo generatorInfo, Compilation compilationWithStaleGeneratedTrees, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.FinalizeCompilationAsync(SolutionState solution, Compilation compilationWithoutGeneratedFiles, CompilationTrackerGeneratorInfo generatorInfo, Compilation compilationWithStaleGeneratedTrees, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.BuildCompilationInfoFromScratchAsync(SolutionState solution, CompilationTrackerGeneratorInfo generatorInfo, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.BuildCompilationInfoAsync(SolutionState solution, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.GetOrBuildCompilationInfoAsync(SolutionState solution, Boolean lockGate, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.SolutionState.CompilationTracker.GetCompilationSlowAsync(SolutionState solution, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.Tools.Tests.MSBuild.MSBuildWorkspaceLoaderTests.AssertProjectLoadsCleanlyAsync(String projectFilePath, ILogger logger, String[] ignoredDiagnostics) in /_/tests/MSBuild/MSBuildWorkspaceLoaderTests.cs:line 147
   at Microsoft.CodeAnalysis.Tools.Tests.MSBuild.MSBuildWorkspaceLoaderTests.AssertTemplateProjectLoadsCleanlyAsync(String templateName, String languageName, String[] ignoredDiagnostics) in /_/tests/MSBuild/MSBuildWorkspaceLoaderTests.cs:line 114
   at Microsoft.CodeAnalysis.Tools.Tests.MSBuild.MSBuildWorkspaceLoaderTests.CSharpTemplateProject_LoadWithNoDiagnostics(String templateName) in /_/tests/MSBuild/MSBuildWorkspaceLoaderTests.cs:line 78
```

/cc @jaredpar 