### PR TITLE
ProcessRunner: do not call WaitForExit until redirection has started

### DIFF
--- a/src/Utilities/ProcessRunner.cs
+++ b/src/Utilities/ProcessRunner.cs
@@ -74,7 +74,6 @@ namespace Microsoft.CodeAnalysis.Tools.Utilities
             Action<Process>? onProcessStartHandler = null,
             CancellationToken cancellationToken = default)
         {
-            var redirectInitiatedLock = new object();
             var redirectInitiated = new ManualResetEventSlim();
 
             var errorLines = new List<string>();
@@ -111,17 +110,9 @@ namespace Microsoft.CodeAnalysis.Tools.Utilities
                         // WaitForExit will only wait for the process to finish redirecting its output/error if we call
                         // BeginOutputReadLine/BeginErrorReadLine prior to calling WaitForExit. If we do not wait for these
                         // methods to be called, its possible to return before we get any data from the process.
-                        lock (redirectInitiatedLock)
-                        {
-                            if (redirectInitiated != null)
-                            {
-                                redirectInitiated.Wait();
-
-                                // Since we got the lock, we are responsible for disposing
-                                redirectInitiated.Dispose();
-                                redirectInitiated = null;
-                            }
-                        }
+                        redirectInitiated.Wait();
+                        redirectInitiated.Dispose();
+                        redirectInitiated = null;
 
                         process.WaitForExit();
                         var result = new ProcessResult(
@@ -135,16 +126,6 @@ namespace Microsoft.CodeAnalysis.Tools.Utilities
 
             _ = cancellationToken.Register(() =>
                 {
-                    lock (redirectInitiatedLock)
-                    {
-                        if (redirectInitiated != null)
-                        {
-                            // Since we got the lock, we are responsible for disposing
-                            redirectInitiated.Dispose();
-                            redirectInitiated = null;
-                        }
-                    }
-
                     if (tcs.TrySetCanceled())
                     {
                         // If the underlying process is still running, we should kill it
@@ -152,6 +133,8 @@ namespace Microsoft.CodeAnalysis.Tools.Utilities
                         {
                             try
                             {
+                                // This will cause Exited to be fired if it already hasn't, ensuring redirectInitiated
+                                // is still disposed even on the cancellation path.
                                 process.Kill();
                             }
                             catch (InvalidOperationException)


### PR DESCRIPTION
If `Process.WaitForExit` is called before `BeginOutputReadLine` and/or `BeginErrorReadLine` is called, `WaitForExit` will not wait until the end of their streams are redirected. This results in a race condition where, if too much time elapses between `Process.Start` and `BeginOutputReadLine`/`BeginErrorReadLine`, it's possible to not receive any output before the process exits and the `TaskCompletionSource` gets its result.

This is particularly problematic since slower build machines that use this tool may randomly see the tool failing due to it not finding the dotnet CLI version, since the version is read from a `dotnet --version` process output redirection.