### PR TITLE
Remove GitHub automation requiring reviews when the SDK version changes

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -189,53 +189,6 @@
       "capabilityId": "IssueResponder",
       "subCapability": "PullRequestResponder",
       "version": "1.0",
-      "id": "jD6WDRtWPw12Nxv4J9blI",
-      "config": {
-        "conditions": {
-          "operator": "and",
-          "operands": [
-            {
-              "name": "isActivitySender",
-              "parameters": {
-                "user": "dotnet-maestro[bot]"
-              }
-            },
-            {
-              "name": "isAction",
-              "parameters": {
-                "action": "opened"
-              }
-            },
-            {
-              "name": "bodyContains",
-              "parameters": {
-                "bodyPattern": "Updates sdk.version"
-              }
-            }
-          ]
-        },
-        "eventType": "pull_request",
-        "eventNames": [
-          "pull_request",
-          "issues",
-          "project_card"
-        ],
-        "taskName": "Require PR approval before merging SDK change",
-        "actions": [
-          {
-            "name": "requestChangesPullRequest",
-            "parameters": {
-              "comment": "This PR changes the .NET SDK version. Review required from before merging."
-            }
-          }
-        ]
-      }
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "PullRequestResponder",
-      "version": "1.0",
       "id": "oxst8BvJCMSxlF_Kgj6PL",
       "config": {
         "conditions": {


### PR DESCRIPTION
Contributes to #2052 by removing the FabricBot automation that requires PR reviews when the .NET SDK version is changed.

/cc @arkalyanms @wtgodbe @mkArtakMSFT @jaredpar