### PR TITLE
Flow live versions of Microsoft.Build, Microsoft.Build.Framework, and Microsoft.Build.Tasks.Core for source-build

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
 
     <!-- msbuild -->
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
 
     <!-- nuget -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
 
     <!-- msbuild -->
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildVersion)" />
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildVersion)" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildTasksCoreVersion)" />
     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildVersion)" />
 
     <!-- nuget -->

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -9,11 +9,6 @@
       <Sha>6f9d6569684cc17015aa6fc5f9d9a5f7580ade97</Sha>
     </Dependency>
     <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
-    <Dependency Name="Microsoft.Build.Framework" Version="17.3.2">
-      <Uri>https://github.com/dotnet/msbuild</Uri>
-      <Sha>561848881bab01749e6d8b03be2869a18ca944f7</Sha>
-    </Dependency>
-    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
     <Dependency Name="Microsoft.Build.Tasks.Core" Version="17.3.2">
       <Uri>https://github.com/dotnet/msbuild</Uri>
       <Sha>561848881bab01749e6d8b03be2869a18ca944f7</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -8,6 +8,21 @@
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>6f9d6569684cc17015aa6fc5f9d9a5f7580ade97</Sha>
     </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
+    <Dependency Name="Microsoft.Build.Framework" Version="17.3.2">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>561848881bab01749e6d8b03be2869a18ca944f7</Sha>
+    </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
+    <Dependency Name="Microsoft.Build.Tasks.Core" Version="17.3.2">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>561848881bab01749e6d8b03be2869a18ca944f7</Sha>
+    </Dependency>
+    <!-- Necessary for source-build. This allows the live version of the package to be used by source-build. -->
+    <Dependency Name="Microsoft.Build" Version="17.3.2">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>561848881bab01749e6d8b03be2869a18ca944f7</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.CodeAnalysis" Version="4.9.0-3.24054.13">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>28e49407a6e4744819bd471707259b99964e441c</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,6 +24,7 @@
     <!-- corefx -->
     <MicrosoftVisualBasicVersion>10.3.0</MicrosoftVisualBasicVersion>
     <!-- msbuild -->
+    <MicrosoftBuildTasksCoreVersion>17.3.2</MicrosoftBuildTasksCoreVersion>
     <MicrosoftBuildVersion>17.3.2</MicrosoftBuildVersion>
     <!-- nuget -->
     <!-- In order tests against the same version of NuGet as the SDK. We have to set this to match. -->


### PR DESCRIPTION
Related to https://github.com/dotnet/source-build/issues/3909

This PR addresses all of the SBRP poison leaks from MSBuild and Microsoft.Build.Tasks.Core reference assemblies found in dotnet-format.

In order to eliminate these poison leaks, we must update Version.Details so that the "live" versions of Microsoft.Build and Microsoft.Build.Tasks.Core will flow to the build of the format repo.