### PR TITLE
Fix CLI sln or proj argument name and description

### DIFF
--- a/src/Resources.resx
+++ b/src/Resources.resx
@@ -334,7 +334,7 @@
     <value>Cannot specify the '--folder' option when writing a binary log.</value>
   </data>
   <data name="SolutionOrProjectArgumentName" xml:space="preserve">
-    <value>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</value>
+    <value>PROJECT | SOLUTION</value>
   </data>
   <data name="SolutionOrProjectArgumentDescription" xml:space="preserve">
     <value>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</value>

--- a/src/xlf/Resources.cs.xlf
+++ b/src/xlf/Resources.cs.xlf
@@ -289,12 +289,12 @@
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentDescription">
         <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <target state="translated">Soubor projektu nebo řešení, se kterým se má operace provést. Pokud soubor není zadaný, příkaz ho bude hledat v aktuálním adresáři.</target>
         <note />
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentName">
-        <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <source>PROJECT | SOLUTION</source>
+        <target state="new">PROJECT | SOLUTION</target>
         <note />
       </trans-unit>
       <trans-unit id="Solution_0_has_ no_projects">

--- a/src/xlf/Resources.de.xlf
+++ b/src/xlf/Resources.de.xlf
@@ -289,12 +289,12 @@
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentDescription">
         <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <target state="translated">Das Projekt oder die Projektmappendatei, die verwendet werden soll. Wenn keine Datei angegeben ist, durchsucht der Befehl das aktuelle Verzeichnis nach einer Datei.</target>
         <note />
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentName">
-        <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <source>PROJECT | SOLUTION</source>
+        <target state="new">PROJECT | SOLUTION</target>
         <note />
       </trans-unit>
       <trans-unit id="Solution_0_has_ no_projects">

--- a/src/xlf/Resources.es.xlf
+++ b/src/xlf/Resources.es.xlf
@@ -289,12 +289,12 @@
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentDescription">
         <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <target state="translated">El archivo de proyecto o solución donde operar. Si no se especifica un archivo, el comando buscará uno en el directorio actual.</target>
         <note />
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentName">
-        <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <source>PROJECT | SOLUTION</source>
+        <target state="translated">PROJECT | SOLUTION</target>
         <note />
       </trans-unit>
       <trans-unit id="Solution_0_has_ no_projects">

--- a/src/xlf/Resources.fr.xlf
+++ b/src/xlf/Resources.fr.xlf
@@ -289,12 +289,12 @@
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentDescription">
         <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <target state="translated">Fichier projet ou solution à utiliser. Si vous ne spécifiez pas de fichier, la commande en recherche un dans le répertoire actuel.</target>
         <note />
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentName">
-        <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <source>PROJECT | SOLUTION</source>
+        <target state="translated">PROJECT | SOLUTION</target>
         <note />
       </trans-unit>
       <trans-unit id="Solution_0_has_ no_projects">

--- a/src/xlf/Resources.it.xlf
+++ b/src/xlf/Resources.it.xlf
@@ -289,12 +289,12 @@
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentDescription">
         <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <target state="translated">File di progetto o di soluzione su cui intervenire. Se non si specifica un file, il comando ne cercherà uno nella directory corrente.</target>
         <note />
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentName">
-        <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <source>PROJECT | SOLUTION</source>
+        <target state="translated">PROJECT | SOLUTION</target>
         <note />
       </trans-unit>
       <trans-unit id="Solution_0_has_ no_projects">

--- a/src/xlf/Resources.ja.xlf
+++ b/src/xlf/Resources.ja.xlf
@@ -289,12 +289,12 @@
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentDescription">
         <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <target state="translated">利用するプロジェクト ファイルまたはソリューション ファイル。指定しない場合、コマンドは現在のディレクトリを検索します。</target>
         <note />
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentName">
-        <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <source>PROJECT | SOLUTION</source>
+        <target state="translated">PROJECT | SOLUTION</target>
         <note />
       </trans-unit>
       <trans-unit id="Solution_0_has_ no_projects">

--- a/src/xlf/Resources.ko.xlf
+++ b/src/xlf/Resources.ko.xlf
@@ -289,12 +289,12 @@
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentDescription">
         <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <target state="translated">수행할 프로젝트 또는 솔루션 파일입니다. 파일을 지정하지 않으면 명령이 현재 디렉토리에서 파일을 검색합니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentName">
-        <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <source>PROJECT | SOLUTION</source>
+        <target state="translated">PROJECT | SOLUTION</target>
         <note />
       </trans-unit>
       <trans-unit id="Solution_0_has_ no_projects">

--- a/src/xlf/Resources.pl.xlf
+++ b/src/xlf/Resources.pl.xlf
@@ -289,12 +289,12 @@
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentDescription">
         <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <target state="translated">Plik projektu lub rozwiązania, dla którego ma zostać wykonana operacja. Jeśli plik nie zostanie podany, polecenie wyszuka go w bieżącym katalogu.</target>
         <note />
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentName">
-        <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <source>PROJECT | SOLUTION</source>
+        <target state="translated">PROJECT | SOLUTION</target>
         <note />
       </trans-unit>
       <trans-unit id="Solution_0_has_ no_projects">

--- a/src/xlf/Resources.pt-BR.xlf
+++ b/src/xlf/Resources.pt-BR.xlf
@@ -289,12 +289,12 @@
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentDescription">
         <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <target state="translated">O arquivo de solução ou projeto para operar. Se um arquivo não for especificado, o comando pesquisará um no diretório atual.</target>
         <note />
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentName">
-        <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <source>PROJECT | SOLUTION</source>
+        <target state="translated">PROJECT | SOLUTION</target>
         <note />
       </trans-unit>
       <trans-unit id="Solution_0_has_ no_projects">

--- a/src/xlf/Resources.ru.xlf
+++ b/src/xlf/Resources.ru.xlf
@@ -289,12 +289,12 @@
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentDescription">
         <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <target state="translated">Файл проекта или решения. Если файл не указан, команда будет искать его в текущем каталоге.</target>
         <note />
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentName">
-        <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <source>PROJECT | SOLUTION</source>
+        <target state="translated">PROJECT | SOLUTION</target>
         <note />
       </trans-unit>
       <trans-unit id="Solution_0_has_ no_projects">

--- a/src/xlf/Resources.tr.xlf
+++ b/src/xlf/Resources.tr.xlf
@@ -289,12 +289,12 @@
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentDescription">
         <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <target state="translated">Üzerinde işlem yapılacak proje veya çözüm dosyası. Bir dosya belirtilmezse komut geçerli dizinde dosya arar.</target>
         <note />
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentName">
-        <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <source>PROJECT | SOLUTION</source>
+        <target state="translated">PROJECT | SOLUTION</target>
         <note />
       </trans-unit>
       <trans-unit id="Solution_0_has_ no_projects">

--- a/src/xlf/Resources.zh-Hans.xlf
+++ b/src/xlf/Resources.zh-Hans.xlf
@@ -289,12 +289,12 @@
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentDescription">
         <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <target state="translated">要操作的项目或解决方案文件。如果没有指定文件，则命令将在当前目录里搜索一个文件。</target>
         <note />
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentName">
-        <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <source>PROJECT | SOLUTION</source>
+        <target state="translated">PROJECT | SOLUTION</target>
         <note />
       </trans-unit>
       <trans-unit id="Solution_0_has_ no_projects">

--- a/src/xlf/Resources.zh-Hant.xlf
+++ b/src/xlf/Resources.zh-Hant.xlf
@@ -289,12 +289,12 @@
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentDescription">
         <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <target state="translated">要操作的專案或解決方案。若未指定檔案，命令就會在目前的目錄中搜尋一個檔案。</target>
         <note />
       </trans-unit>
       <trans-unit id="SolutionOrProjectArgumentName">
-        <source>The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</source>
-        <target state="new">The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.</target>
+        <source>PROJECT | SOLUTION</source>
+        <target state="translated">PROJECT | SOLUTION</target>
         <note />
       </trans-unit>
       <trans-unit id="Solution_0_has_ no_projects">


### PR DESCRIPTION
The common localizable string `SolutionOrProjectArgumentName` has the same value as the string `SolutionOrProjectArgumentDescription`. This results in partially hard to read output of `dotnet format --help`.

I copied the values of the SDK project
(see https://github.com/dotnet/sdk/tree/main/src/Cli/dotnet/xlf). I also copied translated values for
`SolutionOrProjectArgumentDescription`.

Note: I can only confirm the correctnes of the german translation, but
      I trust the translations of the SDK project.

---

For reference see the `dotnet format --help` output with version `8.0.457901+28925c0e519d66c80328aacf973b74e40bb1d5bd`:
```plain
Description:
  Formats code to match editorconfig settings.

Usage:
  dotnet-format [<The project or solution file to operate on. If a file is not specified, the command will search the current directory for one.>] [command] [options]

Arguments:
  <The project or solution file to operate on. If a file is not specified, the command will search the current   The project or solution file to operate on. If a file is not specified, the command will search the current 
  directory for one.>                                                                                            directory for one. [default: /home/dviererbe/Repositories/dotnet/]

Options:
  -?, -h, --help                                                           Show help and usage information
  --version                                                                Show version information
  --diagnostics                                                            A space separated list of diagnostic ids to use as a filter when fixing code style or 3rd party issues. []
  --exclude-diagnostics                                                    A space separated list of diagnostic ids to ignore when fixing code style or 3rd party issues. []
  --severity <error|info|warn>                                             The severity of diagnostics to fix. Allowed values are info, warn, and error.
  --no-restore                                                             Doesn't execute an implicit restore before formatting.
  --verify-no-changes                                                      Verify no formatting changes would be performed. Terminates with a non-zero exit code if any files would have been formatted.
  --include                                                                A list of relative file or folder paths to include in formatting. All files are formatted if empty. []
  --exclude                                                                A list of relative file or folder paths to exclude from formatting. []
  --include-generated                                                      Format files generated by the SDK.
  -v, --verbosity <d|detailed|diag|diagnostic|m|minimal|n|normal|q|quiet>  Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]
  --binarylog <binary-log-path>                                            Log all project or solution load information to a binary log file.
  --report <report-path>                                                   Accepts a file path which if provided will produce a json report in the given directory.

Commands:
  whitespace <The project or solution file to operate on. If a file is not specified, the command will search      Run whitespace formatting. [default: /home/dviererbe/Repositories/dotnet/]
  the current directory for one.>
  style <The project or solution file to operate on. If a file is not specified, the command will search the       Run code style analyzers and apply fixes. [default: /home/dviererbe/Repositories/dotnet/]
  current directory for one.>
  analyzers <The project or solution file to operate on. If a file is not specified, the command will search the   Run 3rd party analyzers and apply fixes. [default: /home/dviererbe/Repositories/dotnet/]
  current directory for one.>
```