### PR TITLE
Prepare the FabricBot config for migration to Policy Service

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -3,32 +3,6 @@
   "tasks": [
     {
       "taskType": "trigger",
-      "capabilityId": "AutoMerge",
-      "subCapability": "AutoMerge",
-      "version": "1.0",
-      "id": "JrwlBTuoi",
-      "config": {
-        "mergeType": "merge",
-        "label": "auto-merge",
-        "taskName": "Auto merge PRs",
-        "minMinutesOpen": "10",
-        "deleteBranches": true,
-        "requireAllStatuses": false,
-        "requireAllStatuses_exemptList": [
-          "codecov",
-          "dependabot",
-          "DotNet Maestro - Int",
-          "DotNet Maestro",
-          "msftbot"
-        ],
-        "removeLabelOnPush": true,
-        "minimumNumberOfCheckRuns": 0,
-        "silentMode": true
-      },
-      "disabled": false
-    },
-    {
-      "taskType": "trigger",
       "capabilityId": "IssueResponder",
       "subCapability": "PullRequestResponder",
       "version": "1.0",

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -40,8 +40,7 @@
         "eventType": "pull_request",
         "eventNames": [
           "pull_request",
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Auto-approve auto-merge PRs",
         "actions": [
@@ -103,8 +102,7 @@
         "eventType": "pull_request",
         "eventNames": [
           "pull_request",
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Auto-approve maestro PRs",
         "actions": [
@@ -144,8 +142,7 @@
         "eventType": "pull_request",
         "eventNames": [
           "pull_request",
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Milestone tracking",
         "actions": [
@@ -191,8 +188,7 @@
         "eventType": "pull_request",
         "eventNames": [
           "pull_request",
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Auto-approve OneLoc PRs",
         "actions": [
@@ -500,8 +496,7 @@
         "eventType": "pull_request",
         "eventNames": [
           "pull_request",
-          "issues",
-          "project_card"
+          "issues"
         ],
         "taskName": "Label Community Pull Requests",
         "actions": [

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -12,6 +12,10 @@
           "operator": "and",
           "operands": [
             {
+              "name": "isPr",
+              "parameters": {}
+            },
+            {
               "name": "labelAdded",
               "parameters": {
                 "user": "dotnet-maestro[bot]",
@@ -63,6 +67,10 @@
         "conditions": {
           "operator": "and",
           "operands": [
+            {
+              "name": "isPr",
+              "parameters": {}
+            },
             {
               "name": "isAction",
               "parameters": {
@@ -126,6 +134,10 @@
           "operator": "and",
           "operands": [
             {
+              "name": "isPr",
+              "parameters": {}
+            },
+            {
               "name": "prTargetsBranch",
               "parameters": {
                 "branchName": "main"
@@ -165,6 +177,10 @@
         "conditions": {
           "operator": "and",
           "operands": [
+            {
+              "name": "isPr",
+              "parameters": {}
+            },
             {
               "name": "isActivitySender",
               "parameters": {
@@ -356,6 +372,10 @@
           "operator": "and",
           "operands": [
             {
+              "name": "isIssue",
+              "parameters": {}
+            },
+            {
               "name": "isOpen",
               "parameters": {}
             },
@@ -392,6 +412,10 @@
         "conditions": {
           "operator": "and",
           "operands": [
+            {
+              "name": "isPr",
+              "parameters": {}
+            },
             {
               "name": "isAction",
               "parameters": {


### PR DESCRIPTION
This updates the FabricBot configuration to address issues we've seen migrating other repositories to the Policy Service automation. There is one behavioral change with a loss of functionality.

1. Remove the auto-merge automation
    - This automation configuration was relying on some rich features of the FabricBot's own auto-merge functionality
    - That functionality was in place before GitHub's own auto-merge functionality
    - Because GitHub has built-in auto-merge capabilities, the Policy Service does not provide its own implementation
    - Policy Service does have automation that allows for a PR to have auto-merge enabled or disabled, but it can't rely on the types of conditions used here
    - The result is there is not a way to port this configuration forward, and a different approach is needed
    - The recommendation is to investigate Arcade-based auto-merge behaviors or implementing a GitHub Action
2. Explicitly add a filter for `isIssue` or `isPr` where that was previously implied
    - There was a task configured for `"eventType" that when ported to Policy Service, this implicit filter will be lost
    - This updates the config to explicitly add that filter so behavior stays the same after the migration
3. Remove references to project automation (it was superfluous)

/cc @mkArtakMSFT @wtgodbe @JohannesLampel 