### PR TITLE
Upgrade netstandard reference to 2.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsDependencyInjectionVersion)" />
+    <PackageVersion Include="NETStandard.Library" Version="2.0.3" />
     <PackageVersion Include="NuGet.Common" Version="$(NuGetVersion)" />
     <PackageVersion Include="NuGet.Configuration" Version="$(NuGetVersion)" />
     <PackageVersion Include="NuGet.Frameworks" Version="$(NuGetVersion)" />

--- a/perf/dotnet-format.Performance.csproj
+++ b/perf/dotnet-format.Performance.csproj
@@ -19,6 +19,8 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="BenchmarkDotNet.Annotations" />
+    <!-- Lift dependency of NETStandard.Library.NETFramework to version produced in SBRP. -->
+    <PackageReference Include="NETStandard.Library" ExcludeAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\dotnet-format.csproj" />

--- a/src/dotnet-format.csproj
+++ b/src/dotnet-format.csproj
@@ -21,7 +21,7 @@
     <!-- Always run on the latest runtime installed. -->
     <RuntimeFrameworkVersion Condition=" '$(DotnetBuildFromSource)' != 'true' ">6.0.0-preview.7.21317.1</RuntimeFrameworkVersion>
     <RollForward>LatestMajor</RollForward>
-    <NETStandardLibraryVersion>2.0.3</NETStandardLibraryVersion>
+
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
 
@@ -54,6 +54,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
+
+    <!-- Lift dependency of NETStandard.Library.NETFramework to version produced in SBRP. -->
+    <PackageReference Include="NETStandard.Library" ExcludeAssets="All" />
 
     <!--
       Explicit System.Text.Json package reference is required for source-build to pick up the live package.

--- a/src/dotnet-format.csproj
+++ b/src/dotnet-format.csproj
@@ -21,7 +21,7 @@
     <!-- Always run on the latest runtime installed. -->
     <RuntimeFrameworkVersion Condition=" '$(DotnetBuildFromSource)' != 'true' ">6.0.0-preview.7.21317.1</RuntimeFrameworkVersion>
     <RollForward>LatestMajor</RollForward>
-
+    <NETStandardLibraryVersion>2.0.3</NETStandardLibraryVersion>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
 

--- a/tests/dotnet-format.UnitTests.csproj
+++ b/tests/dotnet-format.UnitTests.csproj
@@ -39,6 +39,9 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing" />
 
+    <!-- Lift dependency of NETStandard.Library.NETFramework to version produced in SBRP. -->
+    <PackageReference Include="NETStandard.Library" ExcludeAssets="All" />
+
     <!--
       The package "Microsoft.CodeAnalysis.Analyzer.Testing" brings in v5.3 of these NuGet dependencies. In order to
       test against the same verion of NuGet as our configured SDK, we must set the version to be the same.


### PR DESCRIPTION
Updating netstandard in dotnet-format in 6.0.4xx for CVE scanners. Can provide more details offline if needed.