### PR TITLE
Use the release VS image for building

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -10,6 +10,18 @@ trigger:
 - main
 - release/*
 - internal/release/*
+
+schedules:
+  - cron: "0 8 23-29 * 0"
+    displayName: "Monthly smoke test"
+    branches:
+      include:
+        - release/8.0.*
+      exclude:
+        - ""
+    always: true # Run even if there have been no source code changes since the last successful scheduled run
+    batch: false # Do not run the pipeline if the previously scheduled run is in-progress
+
 variables:
 - group: AzureDevOps-Artifact-Feeds-Pats
 extends:
@@ -24,7 +36,7 @@ extends:
         os: windows
     pool:
       name: netcore1espool-internal
-      image: windows.vs2022preview.amd64
+      image: windows.vs2022.amd64
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling

--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -1,0 +1,8 @@
+schemaVersion: 0.0.1
+isProduction: true
+accountableOwners:
+  service: c8aedd2a-1f14-4660-83e2-c74a9417c3cc
+routing:
+  defaultAreaPath:
+    org: devdiv
+    path: DevDiv\NET Developer Experience\CSharp and VB IDE


### PR DESCRIPTION
The preview images no longer exist for vs2022.

Also, adds a scheduled build to ensure the pipeline runs each month. Adds an es-metadata.yml file to classify the repo as a production repo.