### PR TITLE
Really use the release VS image for the build

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -7,8 +7,7 @@ resources:
 
 # Branches that trigger a build on commit
 trigger:
-- main
-- release/*
+- release/8.0.*
 - internal/release/*
 
 schedules:

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -45,7 +45,7 @@ extends:
       displayName: Build and Test
       pool:
         name: NetCore1ESPool-Svc-Internal
-        demands: ImageOverride -equals windows.vs2022preview.amd64
+        demands: ImageOverride -equals windows.vs2022.amd64
       jobs:
       - job: OfficialBuild
         displayName: Official Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,14 +1,15 @@
 # Branches that trigger a build on commit
 trigger:
-- main
-- feature/*
-- release/*
+- release/8.0.*
 
 # Branches that trigger builds on PR
 pr:
-- main
-- feature/*
-- release/*
+  branches:
+    include:
+      - release/8.0.*
+  paths:
+    exclude:
+      - azure-pipelines-official.yml
 
 jobs:
 


### PR DESCRIPTION
Also adds a exclude for the official build so we will not have to wait for PR CI in the future